### PR TITLE
Add build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 
       - name: Build
-        run: npm ci
+        run: |
+          npm ci
+          npm run build
 
       - name: Publish
         run: |


### PR DESCRIPTION
## Description

A build step is needed, otherwise the `lib` directory with the library source is not created.

See https://github.com/faros-ai/faros-js-client/actions/runs/3396552819/jobs/5647744672
It only copies a couple of resource files, package.json, README and LICENSE into the npm package
![Screen Shot 2022-11-07 at 11 30 34 AM](https://user-images.githubusercontent.com/99700024/200363492-4b978e4c-c637-4032-9886-b4ce082df778.png)


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
