### PR TITLE
Add functions to create incremental queries for all models in a schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export {
   RecordIterable,
   buildIncrementalQueryV1,
   buildIncrementalQueryV2,
+  createIncrementalQueriesV1,
+  createIncrementalQueriesV2,
   createIncrementalReadersV1,
   createIncrementalReadersV2,
   createNonIncrementalReaders,

--- a/test/__snapshots__/graphql.test.ts.snap
+++ b/test/__snapshots__/graphql.test.ts.snap
@@ -2,7 +2,14 @@
 
 exports[`graphql build incremental V1 1`] = `
 Object {
-  "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { builds (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid pipeline { pipelineId: id } } } } }",
+  "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { builds (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid pipeline { pipelineId: id } metadata { refreshedAt } } } } }",
+  "name": "cicd_Build",
+}
+`;
+
+exports[`graphql build incremental V1 2`] = `
+Object {
+  "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { builds (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid pipeline { id } metadata { refreshedAt } } } } }",
   "name": "cicd_Build",
 }
 `;
@@ -10,6 +17,13 @@ Object {
 exports[`graphql build incremental V2 1`] = `
 Object {
   "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Build (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id createdAt endedAt name number origin pipeline { pipelineId: id } refreshedAt startedAt status statusCategory statusDetail uid url } }",
+  "name": "cicd_Build",
+}
+`;
+
+exports[`graphql build incremental V2 2`] = `
+Object {
+  "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Build (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id createdAt endedAt name number origin pipeline { id } refreshedAt startedAt status statusCategory statusDetail uid url } }",
   "name": "cicd_Build",
 }
 `;
@@ -108,6 +122,146 @@ exports[`graphql convert to incremental V2 2`] = `
     refreshedAt
   }
 }"
+`;
+
+exports[`graphql create incremental queries V1 1`] = `
+Array [
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { deployments (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid url requestedAt startedAt endedAt application { applicationId: id } build { buildId: id } metadata { refreshedAt } } } } }",
+    "name": "cicd_Deployment",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { deploymentChangesets (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id deployment { deploymentId: id } commit { commitId: id } metadata { refreshedAt } } } } }",
+    "name": "cicd_DeploymentChangeset",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { vcs { commits (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id sha metadata { refreshedAt } } } } }",
+    "name": "vcs_Commit",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { builds (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid pipeline { pipelineId: id } metadata { refreshedAt } } } } }",
+    "name": "cicd_Build",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { pipelines (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "cicd_Pipeline",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { compute { applications (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id name metadata { refreshedAt } } } } }",
+    "name": "compute_Application",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { tasks (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid creator { creatorId: id } metadata { refreshedAt } } } } }",
+    "name": "tms_Task",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskProjectRelationships (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id task { taskId: id } project { projectId: id } metadata { refreshedAt } } } } }",
+    "name": "tms_TaskProjectRelationship",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { projects (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "tms_Project",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskBoardProjectRelationships (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id board { boardId: id } project { projectId: id } metadata { refreshedAt } } } } }",
+    "name": "tms_TaskBoardProjectRelationship",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskBoards (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "tms_TaskBoard",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { users (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "tms_User",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskAssignments (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id assignedAt task { taskId: id } assignee { assigneeId: id } metadata { refreshedAt } } } } }",
+    "name": "tms_TaskAssignment",
+  },
+]
+`;
+
+exports[`graphql create incremental queries V1 2`] = `
+Array [
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { deployments (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid url requestedAt startedAt endedAt application { id } build { id } metadata { refreshedAt } } } } }",
+    "name": "cicd_Deployment",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { deploymentChangesets (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id deployment { id } commit { id } metadata { refreshedAt } } } } }",
+    "name": "cicd_DeploymentChangeset",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { vcs { commits (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id sha metadata { refreshedAt } } } } }",
+    "name": "vcs_Commit",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { builds (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid pipeline { id } metadata { refreshedAt } } } } }",
+    "name": "cicd_Build",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { cicd { pipelines (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "cicd_Pipeline",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { compute { applications (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id name metadata { refreshedAt } } } } }",
+    "name": "compute_Application",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { tasks (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid creator { id } metadata { refreshedAt } } } } }",
+    "name": "tms_Task",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskProjectRelationships (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id task { id } project { id } metadata { refreshedAt } } } } }",
+    "name": "tms_TaskProjectRelationship",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { projects (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "tms_Project",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskBoardProjectRelationships (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id board { id } project { id } metadata { refreshedAt } } } } }",
+    "name": "tms_TaskBoardProjectRelationship",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskBoards (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "tms_TaskBoard",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { users (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id uid metadata { refreshedAt } } } } }",
+    "name": "tms_User",
+  },
+  Object {
+    "gql": "query ($from: builtin_BigInt!, $to: builtin_BigInt!) { tms { taskAssignments (filter: {refreshedAtMillis: {greaterThanOrEqualTo: $from, lessThan: $to}}) { nodes { id assignedAt task { id } assignee { id } metadata { refreshedAt } } } } }",
+    "name": "tms_TaskAssignment",
+  },
+]
+`;
+
+exports[`graphql create incremental queries V2 1`] = `
+Array [
+  Object {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Build (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id createdAt endedAt name number origin pipeline { pipelineId: id } refreshedAt startedAt status statusCategory statusDetail uid url } }",
+    "name": "cicd_Build",
+  },
+  Object {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id } }",
+    "name": "cicd_Pipeline",
+  },
+]
+`;
+
+exports[`graphql create incremental queries V2 2`] = `
+Array [
+  Object {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Build (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id createdAt endedAt name number origin pipeline { id } refreshedAt startedAt status statusCategory statusDetail uid url } }",
+    "name": "cicd_Build",
+  },
+  Object {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id } }",
+    "name": "cicd_Pipeline",
+  },
+]
 `;
 
 exports[`graphql flatten nodes V2 with lists within lists 1`] = `

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -179,12 +179,22 @@ describe('graphql', () => {
     const type = graphSchemaV2.getType('cicd_Build');
     const query1 = sut.buildIncrementalQueryV2(type as gql.GraphQLObjectType);
     expect(query1).toMatchSnapshot();
+    const query2 = sut.buildIncrementalQueryV2(
+      type as gql.GraphQLObjectType,
+      false
+    );
+    expect(query2).toMatchSnapshot();
   });
 
   test('build incremental V1', () => {
     const type = graphSchema.getType('cicd_Build');
     const query1 = sut.buildIncrementalQueryV1(type as gql.GraphQLObjectType);
     expect(query1).toMatchSnapshot();
+    const query2 = sut.buildIncrementalQueryV1(
+      type as gql.GraphQLObjectType,
+      false
+    );
+    expect(query2).toMatchSnapshot();
   });
 
   test('empty cross merge', async () => {
@@ -756,5 +766,19 @@ describe('graphql', () => {
       }
     }`;
     expect(sut.toIncrementalV2(query_without_refreshed_at)).toMatchSnapshot();
+  });
+
+  test('create incremental queries V1', () => {
+    expect(sut.createIncrementalQueriesV1(graphSchema)).toMatchSnapshot();
+    expect(
+      sut.createIncrementalQueriesV1(graphSchema, false)
+    ).toMatchSnapshot();
+  });
+
+  test('create incremental queries V2', () => {
+    expect(sut.createIncrementalQueriesV2(graphSchemaV2)).toMatchSnapshot();
+    expect(
+      sut.createIncrementalQueriesV2(graphSchemaV2, false)
+    ).toMatchSnapshot();
   });
 });

--- a/test/resources/schema-v2.gql
+++ b/test/resources/schema-v2.gql
@@ -208,6 +208,9 @@ type vcs_Repository {
   name: String
 }
 
+"""
+columns and relationships of "cicd_Build"
+"""
 type cicd_Build {
   createdAt: timestamptz
 


### PR DESCRIPTION
## Description

Add functions to create incremental queries for all models in a schema

Reuses the `buildIncrementalQueryV1/V2` functionality with 2 minor changes:

- Introduces a param `avoidCollisions` to control whether to avoid field name collisions when flattening (not needed for my use case, left the current behavior as default).
- Adds the `metadata {refreshedAt}` to the selections in V1.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
