### PR TITLE
Remove default graph

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -183,7 +183,7 @@ export class FarosClient {
     return await this.gql(graph, query, variables);
   }
 
-  async gqlSchema(graph = 'default'): Promise<Schema> {
+  async gqlSchema(graph: string): Promise<Schema> {
     try {
       const {data} = await this.api.get(`/graphs/${graph}/graphql/schema`);
       return data;


### PR DESCRIPTION
## Description

This code was copied from [feeds-sdk](https://github.com/faros-ai/feeds-sdk/blob/main/src/client.ts#L118). However we want to move away from defaulting to the `default` graph in this new library.

Even though this is a breaking change, the only client of the library at the moment is always passing the graph, so we're not breaking any clients.

