### PR TITLE
Make ts-essentials a runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "pino": "^8.5.0",
         "pluralize": "^8.0.0",
         "toposort": "^2.0.2",
+        "ts-essentials": "^7.0.0",
         "typescript-memoize": "^1.1.0",
         "verror": "^1.10.0"
       },
@@ -47,7 +48,6 @@
         "pino-pretty": "^9.0.1",
         "prettier": "2.5.1",
         "tmp": "^0.2.1",
-        "ts-essentials": "^7.0.0",
         "ts-jest": "^27.0.7",
         "typescript": "^4.7.4"
       },
@@ -5928,7 +5928,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
       "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
-      "dev": true,
       "peerDependencies": {
         "typescript": ">=3.7.0"
       }
@@ -6043,7 +6042,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10828,7 +10826,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
       "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
-      "dev": true,
       "requires": {}
     },
     "ts-jest": {
@@ -10895,8 +10892,7 @@
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "typescript-memoize": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pino": "^8.5.0",
     "pluralize": "^8.0.0",
     "toposort": "^2.0.2",
+    "ts-essentials": "^7.0.0",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.0"
   },
@@ -70,7 +71,6 @@
     "pino-pretty": "^9.0.1",
     "prettier": "2.5.1",
     "tmp": "^0.2.1",
-    "ts-essentials": "^7.0.0",
     "ts-jest": "^27.0.7",
     "typescript": "^4.7.4"
   },


### PR DESCRIPTION
Since [we import and invoke functions](https://github.com/faros-ai/faros-js-client/blob/9ba10618204a654f26c15879ad96477fd76e231b/src/graphql/hasura-schema-loader.ts#L8) from the `ts-essentials` library, it needs to be a runtime dependency. Otherwise we'll get runtime errors. For example, in the feeds `release` job:

```
Error: Cannot find module 'ts-essentials'
Require stack:
- /tmp/mock-data-feed-1670638687176/node_modules/faros-js-client/lib/graphql/hasura-schema-loader.js
- /tmp/mock-data-feed-1670638687176/node_modules/faros-js-client/lib/index.js
- /tmp/mock-data-feed-1670638687176/node_modules/faros-feeds-sdk/lib/feed.js
- /tmp/mock-data-feed-1670638687176/node_modules/faros-feeds-sdk/lib/index.js
- /tmp/mock-data-feed-1670638687176/lib/index.js
- /tmp/mock-data-feed-1670638687176/bin/mock-data-feed
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:985:15)
    at Function.Module._load (node:internal/modules/cjs/loader:833:27)
    at Module.require (node:internal/modules/cjs/loader:1057:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/tmp/mock-data-feed-1670638687176/node_modules/faros-js-client/lib/graphql/hasura-schema-loader.js:14:25)
    at Module._compile (node:internal/modules/cjs/loader:1155:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
    at Module.load (node:internal/modules/cjs/loader:1033:32)
    at Function.Module._load (node:internal/modules/cjs/loader:868:12)
    at Module.require (node:internal/modules/cjs/loader:1057:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/tmp/mock-data-feed-1670638687176/node_modules/faros-js-client/lib/graphql/hasura-schema-loader.js',
    '/tmp/mock-data-feed-1670638687176/node_modules/faros-js-client/lib/index.js',
    '/tmp/mock-data-feed-1670638687176/node_modules/faros-feeds-sdk/lib/feed.js',
    '/tmp/mock-data-feed-1670638687176/node_modules/faros-feeds-sdk/lib/index.js',
    '/tmp/mock-data-feed-1670638687176/lib/index.js',
    '/tmp/mock-data-feed-167063[868](https://github.com/faros-ai/feeds/actions/runs/3662164754/jobs/6191054654#step:12:869)7176/bin/mock-data-feed'
  ]
```