### PR TITLE
Sync Faros client implementation with canonical-reports

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -126,7 +126,7 @@ export class FarosClient {
   async addModels(
     graph: string,
     models: string,
-    schema: string
+    schema?: string
   ): Promise<void> {
     if (this.graphVersion !== GraphVersion.V1) {
       throw new VError(

--- a/src/client.ts
+++ b/src/client.ts
@@ -100,6 +100,14 @@ export class FarosClient {
     }
   }
 
+  async createGraph(graph: string): Promise<void> {
+    try {
+      await this.api.put(`/graphs/${graph}`);
+    } catch (err: any) {
+      throw wrapApiError(err, `failed to create graph: ${graph}`);
+    }
+  }
+
   async models(graph: string): Promise<ReadonlyArray<Model>> {
     if (this.graphVersion !== GraphVersion.V1) {
       throw new VError(
@@ -112,6 +120,21 @@ export class FarosClient {
       return data.models;
     } catch (err: any) {
       throw wrapApiError(err, `unable to list models: ${graph}`);
+    }
+  }
+
+  async addCanonicalModels(graph: string): Promise<void> {
+    if (this.graphVersion !== GraphVersion.V1) {
+      throw new VError(
+        `addCanonicalModels is not supported for ${this.graphVersion} graphs`
+      );
+    }
+    try {
+      await this.api.post(`/graphs/${graph}/models?schema=canonical`, '', {
+        headers: {'content-type': 'application/graphql'},
+      });
+    } catch (err: any) {
+      throw wrapApiError(err, `failed to add models to graph: ${graph}`);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -123,10 +123,10 @@ export class FarosClient {
     }
   }
 
-  async addCanonicalModels(
+  async addModels(
     graph: string,
-    models?: string,
-    schema = 'canonical'
+    models: string,
+    schema: string
   ): Promise<void> {
     if (this.graphVersion !== GraphVersion.V1) {
       throw new VError(
@@ -134,14 +134,16 @@ export class FarosClient {
       );
     }
     try {
-      await this.api.post(
-        `/graphs/${graph}/models?schema=${schema}`,
-        models ?? '',
-        {headers: {'content-type': 'application/graphql'}}
-      );
+      await this.api.post(`/graphs/${graph}/models?schema=${schema}`, models, {
+        headers: {'content-type': 'application/graphql'},
+      });
     } catch (err: any) {
       throw wrapApiError(err, `failed to add models to graph: ${graph}`);
     }
+  }
+
+  async addCanonicalModels(graph: string): Promise<void> {
+    return await this.addModels(graph, '', 'canonical');
   }
 
   async namedQuery(name: string): Promise<NamedQuery | undefined> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -123,16 +123,22 @@ export class FarosClient {
     }
   }
 
-  async addCanonicalModels(graph: string): Promise<void> {
+  async addCanonicalModels(
+    graph: string,
+    models?: string,
+    schema = 'canonical'
+  ): Promise<void> {
     if (this.graphVersion !== GraphVersion.V1) {
       throw new VError(
-        `addCanonicalModels is not supported for ${this.graphVersion} graphs`
+        `Adding models is not supported for ${this.graphVersion} graphs`
       );
     }
     try {
-      await this.api.post(`/graphs/${graph}/models?schema=canonical`, '', {
-        headers: {'content-type': 'application/graphql'},
-      });
+      await this.api.post(
+        `/graphs/${graph}/models?schema=${schema}`,
+        models ?? '',
+        {headers: {'content-type': 'application/graphql'}}
+      );
     } catch (err: any) {
       throw wrapApiError(err, `failed to add models to graph: ${graph}`);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -134,8 +134,11 @@ export class FarosClient {
       );
     }
     try {
-      await this.api.post(`/graphs/${graph}/models?schema=${schema}`, models, {
+      await this.api.post(`/graphs/${graph}/models`, models, {
         headers: {'content-type': 'application/graphql'},
+        params: {
+          ...(schema && {schema})
+        },
       });
     } catch (err: any) {
       throw wrapApiError(err, `failed to add models to graph: ${graph}`);


### PR DESCRIPTION
## Description

Sync Faros client implementation with canonical-reports:

- Adds `createGraph` and `addCanonicalModels`

Does not add [encodedGraphName](https://github.com/faros-ai/canonical-reports/blob/5a4bbdd83be2098e50fa8c2194597f3f07729d77/src/clients/faros.ts#L46) since I wasn't sure it'd be needed outside of `canonical-reports`. I need your input here @eskrm @ted-faros 

I also didn't add the [tenant](https://github.com/faros-ai/canonical-reports/blob/5a4bbdd83be2098e50fa8c2194597f3f07729d77/src/clients/faros.ts#L23) property since it's never used. There's also a `tenant` function in the current implementation (I guess it is derived from the API key?).

The last remaining difference between the client in this library vs the client in `canonical-reports` is that we take a `graph` param for all the graph functionality instead of using a single graph per client instance (passed via the client cfg object).

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
