### PR TITLE
FAI-3724: rename first field argument to limit in adapter

### DIFF
--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -392,6 +392,61 @@ describe('AST utilities', () => {
     });
   });
 
+  test('rename first field argument to limit', () => {
+    expectConversion({
+      v1Query: `
+        {
+          cicd {
+            deployments {
+              nodes {
+                uid
+                changeset(first: 1) {
+                  nodes {
+                    commit {
+                      sha
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      v2Query: `
+        {
+          cicd_Deployment {
+            uid
+            changeset(limit: 1) {
+              commit {
+                sha
+              }
+            }
+          }
+        }
+      `,
+      fieldPaths: {
+        cicd_Deployment: {
+          path: 'cicd.deployments.nodes',
+          nestedPaths: {
+            uid: {
+              path: 'uid',
+              type: 'string'
+            },
+            changeset: {
+              path: 'changeset.nodes',
+              nestedPaths: {
+                'commit.sha': {
+                  path: 'commit.sha',
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
   test('all rules', () => {
     expectConversion({
       v1Query: `

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../.tsconfig.json",
   "compilerOptions": {
-    "outDir": "../out/test",
+    "outDir": "../out/test"
   },
   "files": [
     "../node_modules/jest-expect-message/types/index.d.ts"


### PR DESCRIPTION
There's [one](https://github.com/faros-ai/aion/blob/main/resources/flows/tags/application-commit.yml#L39) flow that uses `first` in a nested field. This will convert it to `limit`.