### PR TITLE
FAI-4951: Graph-to-graph Copy Validation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -322,7 +322,8 @@ export class FarosClient {
               yield edge;
             }
             offset += pageSize;
-            hasNextPage = !isEmpty(edges);
+            // break on partial page
+            hasNextPage = edges.length === pageSize;
           }
         },
       };

--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -488,6 +488,11 @@ export function paginateWithOffsetLimitV2(query: string): PaginatedQuery {
                     name: {kind: 'Name', value: 'refreshedAt'},
                     value: {kind: 'EnumValue', value: 'asc'},
                   },
+                  {
+                    kind: 'ObjectField',
+                    name: {kind: 'Name', value: 'id'},
+                    value: {kind: 'EnumValue', value: 'asc'},
+                  },
                 ],
               },
             },

--- a/test/resources/queries/paginated-commits-offset-limit-v2.gql
+++ b/test/resources/queries/paginated-commits-offset-limit-v2.gql
@@ -1,5 +1,5 @@
 query paginatedQuery($offset: Int, $limit: Int, $from: timestamptz, $to: timestamptz) {
-  vcs_Commit(where: {refreshedAt: {_gte: $from, _lt: $to}}, offset: $offset, limit: $limit, order_by: {refreshedAt:asc}) {
+  vcs_Commit(where: {refreshedAt: {_gte: $from, _lt: $to}}, offset: $offset, limit: $limit, order_by: {refreshedAt:asc, id: asc}) {
     id
     author {
       ownerId: id


### PR DESCRIPTION
## Description

Add tie-breaker `order_by` to ensure sort is stable.  Without this, pagination gives erratic results.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change