### PR TITLE
FAI-5090: add new phantoms enum to replicate v1 default

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -187,17 +187,25 @@ export class FarosClient {
       undefined;
   }
 
+  private async doGql(
+    graph: string,
+    query: string,
+    variables?: any): Promise<any> {
+    const req = variables ? {query, variables} : {query};
+    const queryParams = this.queryParameters();
+    const urlSuffix = queryParams ? `?${queryParams}` : '';
+    const {data} = await this.api.post(
+      `/graphs/${graph}/graphql${urlSuffix}`,
+      req
+    );
+    return data;
+  }
+
   /* returns only the data object of a standard qgl response */
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async gql(graph: string, query: string, variables?: any): Promise<any> {
     try {
-      const req = variables ? {query, variables} : {query};
-      const queryParams = this.queryParameters();
-      const urlSuffix = queryParams ? `?${queryParams}` : '';
-      const {data} = await this.api.post(
-        `/graphs/${graph}/graphql${urlSuffix}`,
-        req
-      );
+      const data = await this.doGql(graph, query, variables);
       return data.data;
     } catch (err: any) {
       throw wrapApiError(err, `unable to query graph: ${graph}`);
@@ -208,14 +216,7 @@ export class FarosClient {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async rawGql(graph: string, query: string, variables?: any): Promise<any> {
     try {
-      const req = variables ? {query, variables} : {query};
-      const queryParams = this.queryParameters();
-      const urlSuffix = queryParams ? `?${queryParams}` : '';
-      const {data} = await this.api.post(
-        `/graphs/${graph}/graphql${urlSuffix}`,
-        req
-      );
-      return data;
+      return await this.doGql(graph, query, variables);
     } catch (err: any) {
       throw wrapApiError(err, `unable to query graph: ${graph}`);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -190,36 +190,33 @@ export class FarosClient {
   private async doGql(
     graph: string,
     query: string,
-    variables?: any): Promise<any> {
-    const req = variables ? {query, variables} : {query};
-    const queryParams = this.queryParameters();
-    const urlSuffix = queryParams ? `?${queryParams}` : '';
-    const {data} = await this.api.post(
-      `/graphs/${graph}/graphql${urlSuffix}`,
-      req
-    );
-    return data;
+    variables?: any,
+  ): Promise<any> {
+    try {
+      const req = variables ? {query, variables} : {query};
+      const queryParams = this.queryParameters();
+      const urlSuffix = queryParams ? `?${queryParams}` : '';
+      const {data} = await this.api.post(
+        `/graphs/${graph}/graphql${urlSuffix}`,
+        req,
+      );
+      return data;
+    } catch (err: any) {
+      throw wrapApiError(err, `unable to query graph: ${graph}`);
+    }
   }
 
   /* returns only the data object of a standard qgl response */
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async gql(graph: string, query: string, variables?: any): Promise<any> {
-    try {
-      const data = await this.doGql(graph, query, variables);
-      return data.data;
-    } catch (err: any) {
-      throw wrapApiError(err, `unable to query graph: ${graph}`);
-    }
+    const data = await this.doGql(graph, query, variables);
+    return data.data;
   }
 
   /* returns both data (as res.data) and errors (as res.errors) */
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async rawGql(graph: string, query: string, variables?: any): Promise<any> {
-    try {
-      return await this.doGql(graph, query, variables);
-    } catch (err: any) {
-      throw wrapApiError(err, `unable to query graph: ${graph}`);
-    }
+    return await this.doGql(graph, query, variables);
   }
 
   async gqlNoDirectives(

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,10 +6,10 @@ export interface FarosClientConfig {
 }
 
 export enum Phantom {
-  Only = 'Only',
-  Exclude = 'Exclude',
-  Include = 'Include',
-  IncludeNestedOnly = 'IncludeNestedOnly',
+  Only = 'only',
+  Exclude = 'exclude',
+  Include = 'include',
+  IncludeNestedOnly = 'include-nested-only',
 }
 
 export interface NamedQuery {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,14 @@ export interface FarosClientConfig {
   readonly url: string;
   readonly apiKey: string;
   readonly useGraphQLV2?: boolean;
+  readonly phantoms?: Phantom;
+}
+
+export enum Phantom {
+  Only = 'Only',
+  Exclude = 'Exclude',
+  Include = 'Include',
+  IncludeNestedOnly = 'IncludeNestedOnly',
 }
 
 export interface NamedQuery {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -193,6 +193,29 @@ describe('client', () => {
     mock.done();
   });
 
+  test('gql v2 - default', async () => {
+    const query = `
+      {
+        tms_Task {
+          uid
+        }
+      } `;
+    const mock = nock(apiUrl)
+      .post(
+        '/graphs/g1/graphql',
+        JSON.stringify({query}),
+      )
+      .query({phantoms: 'IncludeNestedOnly'})
+      .reply(200, {data: {result: 'ok'}});
+
+    const clientConfig = {url: apiUrl, apiKey: 'test-key', useGraphQLV2: true};
+    const client = new FarosClient(clientConfig);
+
+    const res = await client.gql('g1', query);
+    mock.done();
+    expect(res).toEqual({result: 'ok'});
+  });
+
   test('gql with variables', async () => {
     const query = `{
       query ($pageSize: Int = 10, $after: Cursor) {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock';
 
 import {FarosClient, Schema} from '../src';
 import {GRAPH_VERSION_HEADER} from '../src/client';
+import {Phantom} from '../src/types';
 
 const apiUrl = 'https://test.faros.ai';
 const clientConfig = {url: apiUrl, apiKey: 'test-key'};
@@ -205,7 +206,7 @@ describe('client', () => {
         '/graphs/g1/graphql',
         JSON.stringify({query}),
       )
-      .query({phantoms: 'IncludeNestedOnly'})
+      .query({phantoms: Phantom.IncludeNestedOnly})
       .reply(200, {data: {result: 'ok'}});
 
     const clientConfig = {url: apiUrl, apiKey: 'test-key', useGraphQLV2: true};


### PR DESCRIPTION
## Description

Add `phantoms` query parameter for v2 queries with default of `Phantom.IncludeNestedOnly`.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
