### PR TITLE
FAI-5080: v2 flow author ids are unknown 

### DIFF
--- a/scripts/load-schema.js
+++ b/scripts/load-schema.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const {outputFile} = require('fs-extra');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const {Command} = require('commander');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const {HasuraSchemaLoader} = require('../lib');
@@ -9,10 +11,13 @@ const program = new Command('perf')
   .description('Run schema loader against Hasura instance')
   .requiredOption('--url <url>', 'Hasura URL')
   .requiredOption('--admin-secret <key>', 'admin secret')
+  .requiredOption('--output <file>', 'location to write schema')
   .action(async (opts) => {
     const loader = new HasuraSchemaLoader(opts.url, opts.adminSecret, true);
     const res = await loader.loadSchema();
-    console.log(JSON.stringify(res, null, 2));
+    const schema = JSON.stringify(res, null, 2);
+    console.log(`writing hasura schema to ${opts.output}...`);
+    await outputFile(opts.output, schema);
   });
 
 program.parse(process.argv);

--- a/src/graphql/hasura-schema-loader.ts
+++ b/src/graphql/hasura-schema-loader.ts
@@ -120,12 +120,12 @@ export class HasuraSchemaLoader implements SchemaLoader {
       }
       // find array relationship represented as reverse object relationships
       for (const objRel of table.object_relationships || []) {
-        const {fkCol, sourceTable} = foreignKeyForReverseObj(objRel);
-        if (fkCol && sourceTable) {
-          if (!res[sourceTable]) {
-            res[sourceTable] = {};
+        const reverseObjFk = foreignKeyForReverseObj(objRel);
+        if (reverseObjFk) {
+          if (!res[reverseObjFk.sourceTable]) {
+            res[reverseObjFk.sourceTable] = {};
           }
-          res[sourceTable][fkCol] = targetTable;
+          res[reverseObjFk.sourceTable][reverseObjFk.fkCol] = targetTable;
         }
       }
     }
@@ -220,11 +220,11 @@ export class HasuraSchemaLoader implements SchemaLoader {
       const reverseBackRefs: BackReference[] = [];
       (table.object_relationships ?? []).forEach(
         (rel) => {
-          const {fkCol, sourceTable} = foreignKeyForReverseObj(rel);
-          if (fkCol && sourceTable) {
+          const reverseObjFk = foreignKeyForReverseObj(rel);
+          if (reverseObjFk) {
             reverseBackRefs.push({
               field: rel.name,
-              model: sourceTable,
+              model: reverseObjFk.sourceTable,
             });
           }
         },

--- a/src/graphql/hasura-schema-loader.ts
+++ b/src/graphql/hasura-schema-loader.ts
@@ -229,7 +229,7 @@ export class HasuraSchemaLoader implements SchemaLoader {
           }
         },
       );
-      backReferences[tableName].concat(reverseBackRefs);
+      backReferences[tableName].push(...reverseBackRefs);
     }
     const modelDeps: [string, string][] = [];
     for (const model of Object.keys(references)) {

--- a/src/graphql/hasura-schema-loader.ts
+++ b/src/graphql/hasura-schema-loader.ts
@@ -11,6 +11,7 @@ import {VError} from 'verror';
 import {
   foreignKeyForArray,
   foreignKeyForObj,
+  foreignKeyForReverseObj,
   isManualConfiguration,
   MULTI_TENANT_COLUMNS,
   parsePrimaryKeys,
@@ -108,11 +109,19 @@ export class HasuraSchemaLoader implements SchemaLoader {
     const res: Dictionary<Dictionary<string>> = {};
     for (const table of source.tables) {
       const targetTable: string = table.table.name;
-      if (table.array_relationships) {
-        for (const arrRel of table.array_relationships) {
-          const fkCol = foreignKeyForArray(arrRel);
-          const sourceTable = remoteTableForArray(arrRel);
-          ok(sourceTable, `missing source table on ${JSON.stringify(arrRel)}`);
+      for (const arrRel of table.array_relationships || []) {
+        const fkCol = foreignKeyForArray(arrRel);
+        const sourceTable = remoteTableForArray(arrRel);
+        ok(sourceTable, `missing source table on ${JSON.stringify(arrRel)}`);
+        if (!res[sourceTable]) {
+          res[sourceTable] = {};
+        }
+        res[sourceTable][fkCol] = targetTable;
+      }
+      // find array relationship represented as reverse object relationships
+      for (const objRel of table.object_relationships || []) {
+        const {fkCol, sourceTable} = foreignKeyForReverseObj(objRel);
+        if (fkCol && sourceTable) {
           if (!res[sourceTable]) {
             res[sourceTable] = {};
           }
@@ -179,6 +188,10 @@ export class HasuraSchemaLoader implements SchemaLoader {
       const tableReferences: Dictionary<Reference> = {};
       for (const rel of table.object_relationships ?? []) {
         const fk = foreignKeyForObj(rel);
+        // skip reverse object relationships
+        if (fk === 'id') {
+          continue;
+        }
         const relFldName = this.camelCaseFieldNames ? camelCase(fk) : fk;
         const relMetadata = {
           field: rel.name,
@@ -204,6 +217,19 @@ export class HasuraSchemaLoader implements SchemaLoader {
           };
         }
       );
+      const reverseBackRefs: BackReference[] = [];
+      (table.object_relationships ?? []).forEach(
+        (rel) => {
+          const {fkCol, sourceTable} = foreignKeyForReverseObj(rel);
+          if (fkCol && sourceTable) {
+            reverseBackRefs.push({
+              field: rel.name,
+              model: sourceTable,
+            });
+          }
+        },
+      );
+      backReferences[tableName].concat(reverseBackRefs);
     }
     const modelDeps: [string, string][] = [];
     for (const model of Object.keys(references)) {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -49,6 +49,20 @@ export function foreignKeyForArray(rel: ArrayRelationship): string {
   return fk;
 }
 
+export function foreignKeyForReverseObj(
+  rel: ObjectRelationship
+): any | undefined {
+  if (isManualConfiguration(rel.using)) {
+    // for reverse object rel, column_mapping contains one entry
+    // mapping literal id to FK on remote table
+    return {
+      fkCol: rel.using.manual_configuration.column_mapping?.id,
+      sourceTable: rel.using.manual_configuration.remote_table?.name
+    };
+  }
+  return undefined;
+}
+
 /**
  * Parse elements of primary key from pkey function definition.
  * e.g. pkey(VARIADIC ARRAY[tenant_id, graph_name, source, uid])

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -51,14 +51,16 @@ export function foreignKeyForArray(rel: ArrayRelationship): string {
 
 export function foreignKeyForReverseObj(
   rel: ObjectRelationship
-): any | undefined {
+): {fkCol: string; sourceTable: string} | undefined {
   if (isManualConfiguration(rel.using)) {
     // for reverse object rel, column_mapping contains one entry
     // mapping literal id to FK on remote table
-    return {
-      fkCol: rel.using.manual_configuration.column_mapping?.id,
-      sourceTable: rel.using.manual_configuration.remote_table?.name
-    };
+    const fkCol = rel.using.manual_configuration.column_mapping?.id;
+    if (fkCol) {
+      const sourceTable = rel.using.manual_configuration.remote_table?.name;
+      ok(sourceTable, `missing remote_table for ${JSON.stringify(rel)}`);
+      return {fkCol, sourceTable};
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Description

Adjustments to `HasuraSchemaLoader` to handle "reverse object relationships".  

[Hasura #48](https://github.com/faros-ai/hasura/pull/48) will replace some array relationships having unique constraints with object relationships pointing the in the reverse direction (i.e. an object relationship where FK is on the remote table).  This change in metadata impacts the schema loader.  The net effect of this PR is to leave schema unchanged by reading equivalent information from the newly introduced reverse object relationships.

This PR has been tested for against Faros CE and verified to produce no change in the schema.  Similarly, it was tested against the new SaaS schema and shown to produce no change.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
