### PR TITLE
FAI-5239: v2 flows not working

### DIFF
--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -280,10 +280,15 @@ export function paginatedQuery(query: string): PaginatedQuery {
   };
 }
 
+export function paginatedQueryV2(query: string): PaginatedQuery {
+  return process.env.GRAPHQL_V2_PAGINATOR === 'relay' ?
+    paginatedWithRelayV2(query) : paginateWithOffsetLimitV2(query);
+}
+
 /**
  * Paginates v2 graphql queries.
  */
-export function paginatedQueryV2(query: string): PaginatedQuery {
+export function paginatedWithRelayV2(query: string): PaginatedQuery {
   const edgesPath: string[] = [];
   const pageInfoPath: string[] = [];
   let firstNode = true;
@@ -1077,8 +1082,7 @@ export function createNonIncrementalReaders(
           pageSize,
           graphSchema,
           false,
-          process.env.GRAPHQL_V2_PAGINATOR === 'relay' ?
-            paginatedQueryV2 : paginateWithOffsetLimitV2,
+          paginatedQueryV2,
           flattenV2
         );
       default:

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -169,10 +169,10 @@ describe('graphql', () => {
     expect(await toArray(flattenedNodes)).toMatchSnapshot();
   });
 
-  test('paginated v2 query', async () => {
+  test('paginated relay v2 query', async () => {
     const query = await loadQueryFile('commits-v2.gql');
     const expectedQuery = await loadQueryFile('paginated-commits-v2.gql');
-    const paginatedQuery = sut.paginatedQueryV2(query);
+    const paginatedQuery = sut.paginatedWithRelayV2(query);
     expect(paginatedQuery.edgesPath).toEqual([
       'vcs_Commit_connection',
       'edges',


### PR DESCRIPTION
## Description

Ensure pagination schemes for extract and flow queries are consistent.

We use pagination in 2 places in this library: (1) in extract queries and (2) flow queries.  Since each has its own id scheme (i.e. object ids are determined by the pagination process, not the underlying data) and we join data across extracts and flows, we need to ensure consistent usage.  

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
