### PR TITLE
FAI-6042: replace epochs with timestamps in jsonb fields

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,7 +5,7 @@ import {
   printSchema,
   visit,
 } from 'graphql';
-import {isPlainObject, keyBy, toNumber} from 'lodash';
+import {isPlainObject, keyBy, mapValues, toNumber} from 'lodash';
 import {Dictionary} from 'ts-essentials';
 import {VError} from 'verror';
 
@@ -71,6 +71,8 @@ export class FarosGraphSchema {
           record[field] = toDate(value as string);
         } else if (fieldType.name.value === 'timestamptz') {
           record[field] = toDateAsISOString(value as string);
+        } else if (fieldType.name.value === 'jsonb') {
+          record[field] = replaceAllEpochsEndingInAt(value);
         } else if (this.objectTypeDefs[fieldType.name.value]) {
           this.fixTimestampFields(value, fieldType.name.value);
         }
@@ -139,4 +141,23 @@ function toDateAsISOString(
       throw new VError('Invalid date: %s', val);
     }
   }
+}
+
+function replaceAllEpochsEndingInAt(
+  obj: any,
+): any {
+  const toDateIfNeeded =
+    (_v: any, _k: string): any => {
+      const isEpoch = _k.endsWith('At') && typeof _v === 'number';
+      return isEpoch ? toDateAsISOString(_v) : _v;
+    };
+  if (Array.isArray(obj)) {
+    return obj.map((o) => replaceAllEpochsEndingInAt(o));
+  }
+  return mapValues(obj, (value, key) => {
+    if (isPlainObject(value)) {
+      return replaceAllEpochsEndingInAt(value);
+    }
+    return toDateIfNeeded(value, key);
+  });
 }

--- a/test/__snapshots__/schema.test.ts.snap
+++ b/test/__snapshots__/schema.test.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`schema fix jsonb - array 1`] = `
+Object {
+  "status": Array [
+    Object {
+      "changedAt": "2021-08-23T20:51:07.746Z",
+      "foo": Object {
+        "category": "Todo",
+        "detail": "To Do",
+        "fixAt": "2021-10-09T03:57:47.746Z",
+        "skippedAt": "not-interesting",
+      },
+      "ignoredAt": "blah",
+    },
+    Object {
+      "bar": Object {
+        "category": "Todo",
+        "detail": "Selected for Development",
+        "fixAt": "2022-02-25T01:17:47.746Z",
+        "skippedAt": "not-interesting",
+      },
+      "changedAt": "2021-08-24T19:16:00.991Z",
+      "skipAt": "nothing",
+    },
+  ],
+  "uid": "abc",
+}
+`;
+
+exports[`schema fix jsonb - object 1`] = `
+Object {
+  "status": Object {
+    "changedAt": "2021-08-23T20:51:07.746Z",
+    "foo": Object {
+      "ackedAt": "ignore",
+      "brokenAt": "2022-02-13T11:31:07.746Z",
+      "category": "Todo",
+      "detail": "To Do",
+    },
+    "submittedAt": "foo",
+  },
+  "uid": "abc",
+}
+`;

--- a/test/resources/schemas/timestamp-schema.gql
+++ b/test/resources/schemas/timestamp-schema.gql
@@ -7,6 +7,10 @@ type ims_Incident {
   createdAt: Timestamp
   createdAtNonNull: Timestamp!
   array: [ims_TimestampObject!]
+  status(
+    """JSON select path"""
+    path: String
+  ): jsonb
 }
 
 type ims_TimestampObject {
@@ -14,6 +18,8 @@ type ims_TimestampObject {
 }
 
 scalar timestamptz
+
+scalar jsonb
 
 type vcs_Commit {
   uid: ID!

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -41,6 +41,53 @@ describe('schema', () => {
     );
   });
 
+  test('fix jsonb - array', () => {
+    const record = {
+      uid: 'abc', status: [
+        {
+          'foo': {
+            'category': 'Todo',
+            'detail': 'To Do',
+            'fixAt': 1633751867746,
+            'skippedAt': 'not-interesting'
+          },
+          'changedAt': 1629751867746,
+          'ignoredAt': 'blah',
+        },
+        {
+          'bar': {
+            'category': 'Todo',
+            'fixAt': 1645751867746,
+            'skippedAt': 'not-interesting',
+            'detail': 'Selected for Development',
+          },
+          'changedAt': 1629832560991,
+          'skipAt': 'nothing'
+        },
+      ],
+    };
+    expect(schema.fixTimestampFields(record, 'ims_Incident'))
+      .toMatchSnapshot();
+  });
+
+  test('fix jsonb - object', () => {
+    const record = {
+      uid: 'abc',
+      status: {
+        'foo': {
+          'category': 'Todo',
+          'detail': 'To Do',
+          'brokenAt': 1644751867746,
+          'ackedAt': 'ignore'
+        },
+        'changedAt': 1629751867746,
+        'submittedAt': 'foo'
+      },
+    };
+    expect(schema.fixTimestampFields(record, 'ims_Incident'))
+      .toMatchSnapshot();
+  });
+
   test('fix nested timestamp field', () => {
     const record = {uid: 'abc', timestampObj: {createdAt: new Date(123)}};
     const json = {uid: 'abc', timestampObj: {createdAt: 123}};


### PR DESCRIPTION
## Description

For `jsonb` fields, recursively replace epochs.  For purpose of this function, an epochs is a number with a property name that ends with 'At'.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
