### PR TITLE
Allow wrapApiError to support non-Errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,8 +27,14 @@ function isAxiosError(error: Error): error is AxiosError {
   return (error as any).isAxiosError;
 }
 
+function isError(error: any): error is Error {
+  return 'name' in error && 'message' in error;
+}
+
 /** Strips verbose properties that libraries like Axios attach to errors */
-export function wrapApiError(error: Error, message?: string): Error {
+export function wrapApiError(maybeError: Error, message?: string): Error {
+  let error = isError(maybeError) ?
+    maybeError : Error(JSON.stringify(maybeError));
   if (!isAxiosError(error)) {
     const cause = VError.cause(error);
     if (cause) {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -23,6 +23,13 @@ describe('errors', () => {
     );
   });
 
+  test('wraps the non-error without drama', () => {
+    const cause: any = {name: 'not-an-error'};
+    expect(sut.wrapApiError(cause, 'message')).toEqual(
+      new WError(Error(JSON.stringify(cause)), 'message')
+    );
+  });
+
   test('includes info field for axios error', () => {
     const error = createAxiosError('message1');
     const wrappedError: any = sut.wrapApiError(error, 'message');


### PR DESCRIPTION
## Description

We encountered an situation where `wrapApiError` threw:

`[ERR_ASSERTION]: err must be an Error at Function.VError.cause `

This change handles that case by wrapping the non-Error.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
