### PR TITLE
Use v2 for QueryBuilder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ import {QueryBuilder, FarosClient} from "faros-js-client";
 const faros = new FarosClient({
     url: 'https://prod.api.faros.ai',
     apiKey: '<your_faros_api_key>',
+    useGraphQLV2: true,
 });
 
 // The QueryBuilder manages the origin for you


### PR DESCRIPTION
## Description

Readme example should have v2 set for client.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
