### PR TITLE
FAI-6878: compress graphql requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -52,6 +52,8 @@ export class FarosClient {
           authorization: cfg.apiKey,
           ...(cfg.useGraphQLV2 && {[GRAPH_VERSION_HEADER]: 'v2'}),
         },
+        maxBodyLength: Infinity, // rely on server to enforce request body size
+        maxContentLength: Infinity // accept any response size
       },
       logger
     );


### PR DESCRIPTION


## Description

Remove default limits on `axios` client

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

