### PR TITLE
[FAI-7161] Add getWebhookEvent to faros client for use by Hermes lambda worker

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -22,7 +22,8 @@ import {
   Phantom,
   SecretName,
   UpdateAccount,
-  WebhookEventStatus,
+  UpdateWebhookEventStatus,
+  WebhookEvent,
 } from './types';
 import {Utils} from './utils';
 
@@ -434,7 +435,7 @@ export class FarosClient {
     };
   }
 
-  async updateWebhookEventStatus(status: WebhookEventStatus): Promise<void> {
+  async updateWebhookEventStatus(status: UpdateWebhookEventStatus): Promise<void> {
     try {
       await this.api.patch(
         `/webhooks/${status.webhookId}/events/${status.eventId}`,
@@ -448,6 +449,25 @@ export class FarosClient {
         err,
         `unable to update status for webhook: ${status.webhookId}` +
           `, event: ${status.eventId}`
+      );
+    }
+  }
+  
+  async getWebhookEvent(webhookId: string, eventId: string): Promise<WebhookEvent> {
+    try {
+      const response = await this.api.get(`/webhooks/${webhookId}/events/${eventId}`);
+      let event = response.data;
+      event = {
+        ...event,
+        createdAt: event.createdAt ? new Date(event.createdAt) : undefined,
+        receivedAt: new Date(event.receivedAt),
+        updatedAt: new Date(event.updatedAt),
+      };
+      return event as WebhookEvent;
+    } catch (err: any) {
+      throw wrapApiError(
+        err,
+        `unable to retrieve event: ${eventId} for webhook: ${webhookId}`
       );
     }
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -435,7 +435,9 @@ export class FarosClient {
     };
   }
 
-  async updateWebhookEventStatus(status: UpdateWebhookEventStatus): Promise<void> {
+  async updateWebhookEventStatus(
+    status: UpdateWebhookEventStatus
+  ): Promise<void> {
     try {
       await this.api.patch(
         `/webhooks/${status.webhookId}/events/${status.eventId}`,
@@ -452,10 +454,15 @@ export class FarosClient {
       );
     }
   }
-  
-  async getWebhookEvent(webhookId: string, eventId: string): Promise<WebhookEvent> {
+
+  async getWebhookEvent(
+    webhookId: string,
+    eventId: string
+  ): Promise<WebhookEvent> {
     try {
-      const response = await this.api.get(`/webhooks/${webhookId}/events/${eventId}`);
+      const response = await this.api.get(
+        `/webhooks/${webhookId}/events/${eventId}`
+      );
       let event = response.data;
       event = {
         ...event,

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,9 +82,27 @@ export interface Model {
   dataSchema: any;
 }
 
-export interface WebhookEventStatus {
+export interface UpdateWebhookEventStatus {
   webhookId: string;
   eventId: string;
   status: string;
   error?: string;
+}
+
+export interface WebhookEvent {
+  id: string;
+  name: string;
+  webhookId: string;
+  event: any;
+  status: WebhookEventStatus;
+  error?: string;
+  createdAt?: Date;
+  receivedAt: Date;
+  updatedAt: Date;
+}
+
+export enum WebhookEventStatus {
+  Pending = 'Pending',
+  Ok = 'OK',
+  Error = 'Error',
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -488,7 +488,7 @@ describe('client', () => {
     const now = new Date();
     const mockReplyEvent: WebhookEvent = {
       id: eventId,
-      webhookId: webhookId,
+      webhookId,
       event: {
         eventType: 'push',
         commit: {
@@ -500,8 +500,8 @@ describe('client', () => {
       createdAt: now,
       receivedAt: now,
       updatedAt: now,
-    }
-    
+    };
+
     const mock = nock(apiUrl)
       .get(`/webhooks/${webhookId}/events/${eventId}`)
       .reply(200, mockReplyEvent);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 
 import {FarosClient, FarosClientConfig, Schema} from '../src';
 import {GRAPH_VERSION_HEADER} from '../src/client';
-import {Phantom} from '../src/types';
+import {Phantom, WebhookEvent, WebhookEventStatus} from '../src/types';
 
 const apiUrl = 'https://test.faros.ai';
 const clientConfig = {url: apiUrl, apiKey: 'test-key'};
@@ -479,6 +479,35 @@ describe('client', () => {
       status: 'error',
       error: 'error message',
     });
+    mock.done();
+  });
+
+  test('get webhook event', async () => {
+    const webhookId = 'testWebhookId';
+    const eventId = 'testEventId';
+    const now = new Date();
+    const mockReplyEvent: WebhookEvent = {
+      id: eventId,
+      webhookId: webhookId,
+      event: {
+        eventType: 'push',
+        commit: {
+          sha: '0xdeadbeef'
+        }
+      },
+      name: 'push',
+      status: WebhookEventStatus.Pending,
+      createdAt: now,
+      receivedAt: now,
+      updatedAt: now,
+    }
+    
+    const mock = nock(apiUrl)
+      .get(`/webhooks/${webhookId}/events/${eventId}`)
+      .reply(200, mockReplyEvent);
+
+    const event = await client.getWebhookEvent(webhookId, eventId);
+    expect(event).toEqual(mockReplyEvent);
     mock.done();
   });
 });


### PR DESCRIPTION
## Description

Add getWebhookEvent to faros client for use by Hermes lambda worker when an event body is omitted from the SQS message due to being too large. getWebhookEvent needs to be exposed in Hermes API as well, that will come as part of the PR to handle large event bodies

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
