### PR TITLE
FAI-7417: Add list type as scalars in table schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6252,9 +6252,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11066,9 +11066,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/src/graphql/hasura-schema-loader.ts
+++ b/src/graphql/hasura-schema-loader.ts
@@ -157,19 +157,16 @@ export class HasuraSchemaLoader implements SchemaLoader {
       if (!type?.fields) {
         continue;
       }
-
       const scalarTypes: any[] = type.fields.filter(
         (t: any) => this.unwrapType(t.type).kind === 'SCALAR'
           && t.description !== 'generated'
       );
-
       const tableScalars: Dictionary<string> = {};
       for (const scalar of scalarTypes) {
         if (!MULTI_TENANT_COLUMNS.has(snakeCase(scalar.name))) {
           tableScalars[scalar.name] = this.unwrapType(scalar.type).name;
         }
       }
-
       scalars[tableName] = tableScalars;
       if (type.description) {
         try {


### PR DESCRIPTION
## Description
Add support for list of scalars into table schema which were currently missing hence sources could not write lists

**Following fields now showing up:**
1. compute_ApplicationSource - repositoryPaths
2. faros_Path - parts
3. identity_Identity - emails
4. ims_Team - tags, teamChain
5. org_Employee - reportingChain
6. org_Team - tags, teamChain
7. qa_TestCase - tags
8. qa_TestExecution - environments, tags
9. qa_TestSuite - tags
10. tms_Team - tags, teamChain
11. vcs_Repository - topics
12. vcs_Team - tags, teamChain

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change