### PR TITLE
FAI-7137 - Add generic request method to client for calling internal endpoints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import {AxiosInstance, AxiosRequestConfig} from 'axios';
+import {AxiosInstance, AxiosRequestConfig, Method} from 'axios';
 import * as gql from 'graphql';
 import {get as traverse, isEmpty, unset} from 'lodash';
 import pino, {Logger} from 'pino';
@@ -194,10 +194,10 @@ export class FarosClient {
   queryParameters(): Dictionary<any> {
     const result: Dictionary<any> = {};
     if (this.graphVersion === GraphVersion.V2) {
-        result.phantoms = this.phantoms;
-        if (this.visibility) {
-            result.visibility = this.visibility;
-        }
+      result.phantoms = this.phantoms;
+      if (this.visibility) {
+        result.visibility = this.visibility;
+      }
     }
     return result;
   }
@@ -232,11 +232,10 @@ export class FarosClient {
         headers['content-encoding'] = 'gzip';
         headers['content-type'] = 'application/json';
       }
-      const {data} = await this.api.post(
-        `/graphs/${graph}/graphql`,
-        req,
-        {headers, params}
-      );
+      const {data} = await this.api.post(`/graphs/${graph}/graphql`, req, {
+        headers,
+        params,
+      });
       return data;
     } catch (err: any) {
       throw wrapApiError(err, `unable to query graph: ${graph}`);
@@ -478,6 +477,25 @@ export class FarosClient {
         err,
         `unable to retrieve event: ${eventId} for webhook: ${webhookId}`
       );
+    }
+  }
+
+  async request<T>(
+    method: Method,
+    path: string,
+    data?: any,
+    params?: any
+  ): Promise<T> {
+    try {
+      const response = await this.api.request({
+        method,
+        url: path,
+        data,
+        params,
+      });
+      return response.data;
+    } catch (err: any) {
+      throw wrapApiError(err, `unable to perform request: ${path}`);
     }
   }
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -179,11 +179,14 @@ describe('client', () => {
   });
 
   test('check v2 header value', async () => {
-    await expectV2Request({
-      url: apiUrl,
-      apiKey: 'test-key',
-      useGraphQLV2: true,
-    }, true);
+    await expectV2Request(
+      {
+        url: apiUrl,
+        apiKey: 'test-key',
+        useGraphQLV2: true,
+      },
+      true
+    );
   });
 
   async function expectV2Request(
@@ -221,8 +224,8 @@ describe('client', () => {
 
   test('v2 query parameters - default', async () => {
     const expected = new URLSearchParams({
-        phantoms: Phantom.IncludeNestedOnly,
-      });
+      phantoms: Phantom.IncludeNestedOnly,
+    });
     const clientConfig = {
       url: apiUrl,
       apiKey: 'test-key',
@@ -233,8 +236,8 @@ describe('client', () => {
 
   test('v2 query parameters - custom phantoms', async () => {
     const expected = new URLSearchParams({
-        phantoms: Phantom.Exclude,
-      });
+      phantoms: Phantom.Exclude,
+    });
     const clientConfig = {
       url: apiUrl,
       apiKey: 'test-key',
@@ -282,7 +285,7 @@ describe('client', () => {
     const mock = nock(apiUrl)
       .post(
         '/graphs/g1/graphql',
-        JSON.stringify({query, variables: {pageSize: 100, after: 'abc'}}),
+        JSON.stringify({query, variables: {pageSize: 100, after: 'abc'}})
       )
       .reply(200, {
         data: {tms: {tasks: {edges: [{node: {uid: '1'}}, {node: {uid: '2'}}]}}},
@@ -492,8 +495,8 @@ describe('client', () => {
       event: {
         eventType: 'push',
         commit: {
-          sha: '0xdeadbeef'
-        }
+          sha: '0xdeadbeef',
+        },
       },
       name: 'push',
       status: WebhookEventStatus.Pending,
@@ -508,6 +511,16 @@ describe('client', () => {
 
     const event = await client.getWebhookEvent(webhookId, eventId);
     expect(event).toEqual(mockReplyEvent);
+    mock.done();
+  });
+
+  test('generic request', async () => {
+    const path = `/prefix/endpoint`;
+    const body = {foo: 'bar'};
+    const responseBody = {result: 'ok'};
+    const mock = nock(apiUrl).post(path, body).reply(200, responseBody);
+    const response = await client.request('POST', path, body);
+    expect(response).toEqual(responseBody);
     mock.done();
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -515,7 +515,7 @@ describe('client', () => {
   });
 
   test('generic request', async () => {
-    const path = `/prefix/endpoint`;
+    const path = '/prefix/endpoint';
     const body = {foo: 'bar'};
     const responseBody = {result: 'ok'};
     const mock = nock(apiUrl).post(path, body).reply(200, responseBody);


### PR DESCRIPTION
## Description

For calling Faros API endpoints not exposed publicly, and more generally for calling any Faros API endpoint that doesn't currently have a provided client method.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
