### PR TITLE
Add category/details converter

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,4 +115,27 @@ export class Utils {
       setTimeout(resolve, millis);
     });
   }
+
+static toCategoryDetail<EnumType extends {Custom: any}>(
+    enumObject: EnumType & Record<string, any>,
+    category: string,
+    categoryMapping: Record<string, string> = {}
+  ): {
+    category: EnumType[keyof EnumType];
+    detail: string;
+  } {
+    const enumSymbol =
+      enumObject[category] ?? enumObject[categoryMapping[category]];
+    if (enumSymbol) {
+      return {
+        category: enumSymbol,
+        detail: category,
+      };
+    }
+
+    return {
+      category: enumObject.Custom,
+      detail: category,
+    };
+  }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -150,4 +150,64 @@ describe('parse primary keys', () => {
       true)
     ).toEqual(['lat', 'lon']);
   });
+
+  describe('to category detail converter', () => {
+    enum Example {
+      Option1 = 'Option1',
+      Option2 = 'Option2',
+      Custom = 'Custom',
+    }
+
+    test('category matches enum symbol', () => {
+      expect(
+        sut.Utils.toCategoryDetail(Example, 'Option1')
+      ).toEqual({
+        category: Example.Option1,
+        detail: 'Option1',
+      });
+    });
+
+    test('mapped category matches enum symbol', () => {
+      const sourceCategory = 'Option One';
+      const questionCategoryMapping = {
+        [sourceCategory]: 'Option1',
+      };
+
+      expect(
+        sut.Utils.toCategoryDetail(
+          Example,
+          sourceCategory,
+          questionCategoryMapping
+        )
+      ).toEqual({
+        category: Example.Option1,
+        detail: sourceCategory,
+      });
+    });
+
+    test('unmatched category', () => {
+      const sourceCategory = 'Option One';
+      const questionCategoryMapping = {
+        [sourceCategory]: 'NotARealCategory',
+      };
+
+      expect(
+        sut.Utils.toCategoryDetail(
+          Example,
+          sourceCategory,
+          questionCategoryMapping
+        )
+      ).toEqual({
+        category: Example.Custom,
+        detail: sourceCategory,
+      });
+
+      expect(
+        sut.Utils.toCategoryDetail(Example, sourceCategory)
+      ).toEqual({
+        category: Example.Custom,
+        detail: sourceCategory,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description

We do the conversion from `category: string` => `{category: SomeEnum.Symbol; detail: string}` very often in our codebase. In fact, I have three cases where this is needed just in [this](https://github.com/faros-ai/airbyte-connectors/pull/1170) PR

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
