### PR TITLE
Move cleanAndTruncate from to Utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,7 @@ export class Utils {
     });
   }
 
-static toCategoryDetail<EnumType extends {Custom: any}>(
+  static toCategoryDetail<EnumType extends {Custom: any}>(
     enumObject: EnumType & Record<string, any>,
     category: string,
     categoryMapping: Record<string, string> = {}
@@ -141,7 +141,10 @@ static toCategoryDetail<EnumType extends {Custom: any}>(
     };
   }
 
-  static cleanAndTruncate(str?: string, maxLength?: number): string | null | undefined {
+  static cleanAndTruncate(
+    str?: string,
+    maxLength?: number
+  ): string | null | undefined {
     if (!str) {
       return str;
     }
@@ -152,7 +155,10 @@ static toCategoryDetail<EnumType extends {Custom: any}>(
     } else {
       // If the last character is part of a unicode surrogate pair, include the next character
       const lastChar = str.codePointAt(length - 1) ?? 0;
-      result = lastChar > 65535 ? str.substring(0, length + 1) : str.substring(0, length);
+      result =
+        lastChar > 65535
+          ? str.substring(0, length + 1)
+          : str.substring(0, length);
     }
     // eslint-disable-next-line no-control-regex
     return result.replace(/\u0000/g, '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ export class Utils {
     if (str.length <= length) {
       result = str;
     } else {
-      // If the last character is part of a unicode surrogate pair, 
+      // If the last character is part of a unicode surrogate pair,
       // include the next character
       const lastChar = str.codePointAt(length - 1) ?? 0;
       result =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,8 @@ export class Utils {
     if (str.length <= length) {
       result = str;
     } else {
-      // If the last character is part of a unicode surrogate pair, include the next character
+      // If the last character is part of a unicode surrogate pair, 
+      // include the next character
       const lastChar = str.codePointAt(length - 1) ?? 0;
       result =
         lastChar > 65535

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import {Duration} from 'luxon';
 import VError from 'verror';
 
+// Max length for free-form description text fields such as issue body
+const MAX_TEXT_LENGTH = 1000;
 
 export class Utils {
   static urlWithoutTrailingSlashes(url: string): string {
@@ -137,5 +139,22 @@ static toCategoryDetail<EnumType extends {Custom: any}>(
       category: enumObject.Custom,
       detail: category,
     };
+  }
+
+  static cleanAndTruncate(str?: string, maxLength?: number): string | null | undefined {
+    if (!str) {
+      return str;
+    }
+    const length = maxLength ?? MAX_TEXT_LENGTH;
+    let result: string;
+    if (str.length <= length) {
+      result = str;
+    } else {
+      // If the last character is part of a unicode surrogate pair, include the next character
+      const lastChar = str.codePointAt(length - 1) ?? 0;
+      result = lastChar > 65535 ? str.substring(0, length + 1) : str.substring(0, length);
+    }
+    // eslint-disable-next-line no-control-regex
+    return result.replace(/\u0000/g, '');
   }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -210,4 +210,13 @@ describe('parse primary keys', () => {
       });
     });
   });
+
+  describe('clean and truncate', () => {
+    test('should truncate strings', () => {
+      const str = 'abc123😍\u0000';
+      expect(sut.Utils.cleanAndTruncate(str)).toEqual('abc123😍');
+      expect(sut.Utils.cleanAndTruncate(str, 3)).toEqual('abc');
+      expect(sut.Utils.cleanAndTruncate(str, 7)).toEqual('abc123😍');
+    });
+  });
 });


### PR DESCRIPTION
## Description

Copied from [Hermes](https://github.com/faros-ai/hermes/blob/c0f3ca032486052b4fa7fcad1919084c2f783a0a/packages/worker/src/converters/utils.ts)

For reusability across our codebase

Ask me how I found this :D

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
