### PR TITLE
FAI-7767 V2 Queries don't get modified under "adapt v1 query to v2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@types/lodash": "^4.14.194",
         "@types/luxon": "^3.1.0",
         "@types/node": "^16.11.41",
-        "@types/pino": "^7.0.5",
         "@types/pluralize": "^0.0.29",
         "@types/tmp": "^0.2.0",
         "@types/toposort": "^2.0.3",
@@ -1394,16 +1393,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
       "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
       "dev": true
-    },
-    "node_modules/@types/pino": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
-      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
-      "deprecated": "This is a stub types definition. pino provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "pino": "*"
-      }
     },
     "node_modules/@types/pluralize": {
       "version": "0.0.29",
@@ -6881,15 +6870,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
       "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
       "dev": true
-    },
-    "@types/pino": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
-      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
-      "dev": true,
-      "requires": {
-        "pino": "*"
-      }
     },
     "@types/pluralize": {
       "version": "0.0.29",

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -1,4 +1,5 @@
 import * as gql from 'graphql';
+import {Maybe} from 'graphql/jsutils/Maybe';
 import _ from 'lodash';
 import {DateTime} from 'luxon';
 import {singular} from 'pluralize';
@@ -305,7 +306,8 @@ export function asV2AST(ast: gql.ASTNode, typeInfo: gql.TypeInfo): gql.ASTNode {
 export class QueryAdapter {
   constructor(
     private readonly faros: FarosClient,
-    private readonly v1Schema: gql.GraphQLSchema
+    private readonly v1Schema: gql.GraphQLSchema,
+    private readonly v2Schema: Maybe<gql.GraphQLSchema> = undefined
   ) {
     if (faros.graphVersion !== 'v2') {
       throw new VError(
@@ -427,7 +429,7 @@ export class QueryAdapter {
     const v1TypeInfo = new gql.TypeInfo(this.v1Schema);
     const nodePaths = this.nodePaths(v1AST, v1TypeInfo);
     let v2Query: string;
-    if (validationErrors.length > 0) {
+    if (this.v2Schema && validationErrors.length > 0) {
       const v2ValidationErrors = gql.validate(this.v2Schema, v1AST);
       if (v2ValidationErrors.length > 0) {
         throw new VError(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,7 +46,7 @@ export function wrapApiError(maybeError: Error, message?: string): Error {
   }
 
   const prefix = message ? `${message}: ` : '';
-  const res: AxiosResponse<any, any> | undefined = error.response;
+  const res: AxiosResponse<any> | undefined = error.response;
   const info = {
     req:
       error.config || error.request


### PR DESCRIPTION
## Description
In order to support V2 Flows, we need to make sure the adapter doesn't attempt to modify V2 queries.

## Type of change
- [ ] Bug fix
- [X] New feature
- [X] Breaking change


