### PR TITLE
FAI-9498: Support JSON Array with GraphQL Schema hint

### DIFF
--- a/test/__snapshots__/graphql.test.ts.snap
+++ b/test/__snapshots__/graphql.test.ts.snap
@@ -356,6 +356,10 @@ exports[`graphql create incremental queries V2 1`] = `
     "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id } }",
     "name": "cicd_Pipeline",
   },
+  {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Artifact (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id tags uid } }",
+    "name": "cicd_Artifact",
+  },
 ]
 `;
 
@@ -368,6 +372,10 @@ exports[`graphql create incremental queries V2 2`] = `
   {
     "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id } }",
     "name": "cicd_Pipeline",
+  },
+  {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Artifact (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id tags uid } }",
+    "name": "cicd_Artifact",
   },
 ]
 `;

--- a/test/resources/schemas/schema-v2.gql
+++ b/test/resources/schemas/schema-v2.gql
@@ -46,6 +46,14 @@ type query_root {
     """limit the number of rows returned"""
     limit: Int
   ): [cicd_Build!]!
+
+  """
+  fetch data from the table: "cicd_Artifact"
+  """
+  cicd_Artifact(
+    """limit the number of rows returned"""
+    limit: Int
+  ): [cicd_Artifact!]!
 }
 
 type ims_Incident {
@@ -259,4 +267,21 @@ type cicd_Pipeline {
 }
 
 scalar jsonb
+
+"""
+"farosModel": "cicd_Artifact"
+"""
+type cicd_Artifact {
+
+  """generated"""
+  id: String!
+
+  """array"""
+  tags(
+    """JSON select path"""
+    path: String
+  ): jsonb
+
+  uid: String!
+}
 


### PR DESCRIPTION
## Description

Use GraphQL schema hint (in the form of field `description` value of `array`) to indicate `jsonb` field contains array value.  This impacts the metadata produced by `flatten` utilities for our extract jobs.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
