### PR TITLE
FAI-9931: Better error message for Invalid GraphQL type

### DIFF
--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -754,10 +754,13 @@ export function flattenV2(
         enter(node): boolean | void {
           const name = node.alias?.value ?? node.name.value;
           fieldPath.push(name);
+          const type = typeInfo.getType();
           if (!rootPath.length) {
             rootPath.push(...fieldPath);
+            if (!type) {
+              throw new VError('invalid type \'%s\'', name);
+            }
           }
-          const type = typeInfo.getType();
           if (isListType(type)) {
             const listPath = fieldPath.join('.');
             listPaths.push(listPath);

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -195,6 +195,12 @@ describe('graphql', () => {
     expect(await toArray(flattenedNodes)).toMatchSnapshot();
   });
 
+  test('flatten nodes V2 with invalid type', () => {
+    expect(() => sut.flattenV2('{foo_Bar{id}}', graphSchemaV2)).toThrow(
+      'invalid type \'foo_Bar\''
+    );
+  });
+
   test('paginated relay v2 query', async () => {
     const query = await loadQueryFile('commits-v2.gql');
     const expectedQuery = await loadQueryFile('paginated-commits-v2.gql');


### PR DESCRIPTION
## Description

Throw exception in `flattener` if root type is invalid 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

