### PR TITLE
FAI-9504: Include scalar arrays in incremental queries

### DIFF
--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -1452,6 +1452,12 @@ function isV2ModelType(type: any): type is gql.GraphQLObjectType {
     : false;
 }
 
+function isScalar(type: any): boolean {
+  const unwrapped = unwrapType(type);
+  return gql.isScalarType(unwrapped) ||
+    (gql.isListType(unwrapped) && gql.isScalarType(unwrapped.ofType));
+}
+
 /**
  * Creates an incremental query from a model type.
  * The selections will include:
@@ -1479,7 +1485,7 @@ export function buildIncrementalQueryV2(
   fieldsObj[ID_FLD] = true;
   for (const fldName of Object.keys(type.getFields())) {
     const field = type.getFields()[fldName];
-    if (gql.isScalarType(unwrapType(field.type))) {
+    if (isScalar(field.type)) {
       const reference = references[fldName];
       if (reference) {
         // This is a (scalar) foreign key to a top-level model

--- a/test/__snapshots__/graphql.test.ts.snap
+++ b/test/__snapshots__/graphql.test.ts.snap
@@ -353,7 +353,7 @@ exports[`graphql create incremental queries V2 1`] = `
     "name": "cicd_Build",
   },
   {
-    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id } }",
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id tags } }",
     "name": "cicd_Pipeline",
   },
   {
@@ -370,7 +370,7 @@ exports[`graphql create incremental queries V2 2`] = `
     "name": "cicd_Build",
   },
   {
-    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id } }",
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id tags } }",
     "name": "cicd_Pipeline",
   },
   {

--- a/test/resources/schemas/schema-v2.gql
+++ b/test/resources/schemas/schema-v2.gql
@@ -264,6 +264,7 @@ type cicd_Build {
 type cicd_Pipeline {
   """generated"""
   id: String!
+  tags: [String!]
 }
 
 scalar jsonb


### PR DESCRIPTION
## Description

Ensure that scalar array fields (e.g `text[]`) are included in incremental queries

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

