### PR TITLE
FAI-10363: Remove superfluous FKs from incremental queries

### DIFF
--- a/test/__snapshots__/graphql.test.ts.snap
+++ b/test/__snapshots__/graphql.test.ts.snap
@@ -380,6 +380,23 @@ exports[`graphql create incremental queries V2 2`] = `
 ]
 `;
 
+exports[`graphql create incremental queries V2 3`] = `
+[
+  {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Build (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id createdAt endedAt name number origin refreshedAt startedAt status statusCategory statusDetail uid url } }",
+    "name": "cicd_Build",
+  },
+  {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Pipeline (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id tags } }",
+    "name": "cicd_Pipeline",
+  },
+  {
+    "gql": "query ($from: timestamptz!, $to: timestamptz!) { cicd_Artifact (where: {refreshedAt: {_gte: $from, _lt: $to}}) { id tags uid } }",
+    "name": "cicd_Artifact",
+  },
+]
+`;
+
 exports[`graphql create incremental queries V2 when missing expected field 2`] = `"expected missing_field to be a reference field of cicd_Pipeline (foreign key to cicd_Organization)"`;
 
 exports[`graphql create incremental queries V2 with primary keys/references 1`] = `

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -888,6 +888,14 @@ describe('graphql', () => {
     expect(
       sut.createIncrementalQueriesV2(graphSchemaV2, undefined, undefined, false)
     ).toMatchSnapshot();
+    expect(
+      sut.createIncrementalQueriesV2(graphSchemaV2,
+        undefined,
+        undefined,
+        false,
+        true,
+      ),
+    ).toMatchSnapshot();
   });
 
   test('create incremental queries V2 with primary keys/references', () => {


### PR DESCRIPTION
## Description

Add `scalarsOnly` option to exclude FKs queried as nested fragments.  They aren't needed for some use cases.

Prior behavior produced extra FKs like `pullRequestFk` in below:

```
query paginatedQuery($id: String, $limit: Int, $from: timestamptz!, $to: timestamptz!) {
  vcs_PullRequestComment(
    where: {_and: [{refreshedAt: {_gte: $from, _lt: $to}}, {id: {_gt: $id}}]}
    order_by: {id: asc}
    limit: $limit
  ) {
    _id: id
    id
    author {
      authorFk: id
    }
    authorId
    comment
    createdAt
    isPhantom
    number
    origin
    pullRequest {
      pullRequestFk: id
    }
    pullRequestId
    refreshedAt
    updatedAt
  }
} 
```

With `scalarsOnly` set to true, the output will be:

```
query paginatedQuery($id: String, $limit: Int, $from: timestamptz!, $to: timestamptz!) {
  vcs_PullRequestComment(
    where: {_and: [{refreshedAt: {_gte: $from, _lt: $to}}, {id: {_gt: $id}}]}
    order_by: {id: asc}
    limit: $limit
  ) {
    _id: id
    id
    authorId
    comment
    createdAt
    isPhantom
    number
    origin
    pullRequestId
    refreshedAt
    updatedAt
  }
} 
```
## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

