### PR TITLE
FAI-14503: Batch Hermes GraphQL queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.5",
         "axios-retry": "^4.0.0",
         "commander": "^9.3.0",
+        "date-format": "^4.0.14",
         "fs-extra": "^11.2.0",
         "graphql": "^16.8.1",
         "is-retry-allowed": "^2.2.0",
@@ -22,6 +23,7 @@
         "pino": "^9.0.0",
         "pluralize": "^8.0.0",
         "toposort": "^2.0.2",
+        "traverse": "^0.6.10",
         "ts-essentials": "^9.3.2",
         "typescript-memoize": "^1.1.0",
         "verror": "^1.10.0"
@@ -35,6 +37,7 @@
         "@types/pluralize": "^0.0.33",
         "@types/tmp": "^0.2.0",
         "@types/toposort": "^2.0.3",
+        "@types/traverse": "^0.6.37",
         "@types/verror": "^1.10.4",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
@@ -1387,6 +1390,12 @@
       "integrity": "sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==",
       "dev": true
     },
+    "node_modules/@types/traverse": {
+      "version": "0.6.37",
+      "resolved": "https://registry.npmjs.org/@types/traverse/-/traverse-0.6.37.tgz",
+      "integrity": "sha512-c90MVeDiUI1FhOZ6rLQ3kDWr50YE8+paDpM+5zbHjbmsqEp2DlMYkqnZnwbK9oI+NvDe8yRajup4jFwnVX6xsA==",
+      "dev": true
+    },
     "node_modules/@types/verror": {
       "version": "1.10.10",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.10.tgz",
@@ -1721,6 +1730,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1728,6 +1752,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/assert-plus": {
@@ -1755,6 +1799,20 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axios": {
@@ -2025,6 +2083,50 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2234,6 +2336,62 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -2289,6 +2447,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2337,6 +2527,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ejs": {
@@ -2394,6 +2597,127 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -2888,6 +3212,14 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -2938,7 +3270,33 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2961,6 +3319,29 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2968,6 +3349,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2980,6 +3373,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -3029,6 +3438,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -3047,6 +3471,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3068,6 +3503,17 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3077,11 +3523,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3272,11 +3767,97 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.13.1",
@@ -3290,6 +3871,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3297,6 +3909,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3317,6 +3943,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3329,6 +3972,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3338,6 +3992,21 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -3345,6 +4014,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-retry-allowed": {
@@ -3358,6 +4044,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3369,6 +4080,96 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+      "dependencies": {
+        "call-bound": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4345,6 +5146,14 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4488,6 +5297,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -4535,6 +5382,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -4852,6 +5715,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5033,6 +5904,46 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5146,6 +6057,24 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5165,6 +6094,37 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.4.3",
@@ -5192,6 +6152,49 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5211,6 +6214,74 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -5331,6 +6402,59 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -5468,6 +6592,22 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
+    "node_modules/traverse": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.10.tgz",
+      "integrity": "sha512-hN4uFRxbK+PX56DxYiGHsTn2dME3TVr9vbNqlQGcGcPhJAn+tdP126iA+TArMpI4YSgnTkMWyoLl5bf81Hi5TA==",
+      "dependencies": {
+        "gopd": "^1.0.1",
+        "typedarray.prototype.slice": "^1.0.3",
+        "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ts-essentials": {
       "version": "9.4.2",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.2.tgz",
@@ -5583,6 +6723,97 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typedarray.prototype.slice": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
+      "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "math-intrinsics": "^1.1.0",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
@@ -5600,6 +6831,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.1.tgz",
       "integrity": "sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA=="
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -5703,6 +6951,86 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "axios": "^1.6.5",
     "axios-retry": "^4.0.0",
     "commander": "^9.3.0",
+    "date-format": "^4.0.14",
     "fs-extra": "^11.2.0",
     "graphql": "^16.8.1",
     "is-retry-allowed": "^2.2.0",
@@ -45,6 +46,7 @@
     "pino": "^9.0.0",
     "pluralize": "^8.0.0",
     "toposort": "^2.0.2",
+    "traverse": "^0.6.10",
     "ts-essentials": "^9.3.2",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.0"
@@ -58,6 +60,7 @@
     "@types/pluralize": "^0.0.33",
     "@types/tmp": "^0.2.0",
     "@types/toposort": "^2.0.3",
+    "@types/traverse": "^0.6.37",
     "@types/verror": "^1.10.4",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
@@ -78,9 +81,12 @@
   "jest": {
     "coverageDirectory": "out/coverage",
     "transform": {
-      "\\.[jt]sx?$": [ "ts-jest", {
-        "tsconfig": "test/tsconfig.json"
-      }]
+      "\\.[jt]sx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "test/tsconfig.json"
+        }
+      ]
     },
     "preset": "ts-jest",
     "setupFilesAfterEnv": [

--- a/src/date-format.d.ts
+++ b/src/date-format.d.ts
@@ -1,0 +1,1 @@
+declare module 'date-format';

--- a/src/graphql/client/graphql-client.ts
+++ b/src/graphql/client/graphql-client.ts
@@ -1,0 +1,1112 @@
+import {randomUUID} from 'crypto';
+import dateformat from 'date-format';
+import {EnumType, jsonToGraphQLQuery} from 'json-to-graphql-query';
+import {
+  clone,
+  difference,
+  flatMap,
+  get,
+  groupBy,
+  has,
+  intersection,
+  isDate,
+  isEmpty,
+  isNil,
+  isObject,
+  isString,
+  keys,
+  max,
+  orderBy,
+  pick,
+  reverse,
+  set,
+  unset,
+  unzip,
+} from 'lodash';
+import pino from 'pino';
+import traverse from 'traverse';
+import {assert, Dictionary} from 'ts-essentials';
+import {VError} from 'verror';
+
+//import {AirbyteLogger} from 'faros-airbyte-cdk';
+import {paginatedQueryV2} from '../graphql';
+import {SchemaLoader} from '../schema';
+import {Schema} from '../types';
+//import {StreamNameSeparator} from '../converters/converter';
+import {OriginProvider} from './graphql-writer';
+import {
+  DeletionRecord, Logger,
+  Operation, StreamNameSeparator,
+  TimestampedRecord,
+  UpdateRecord,
+  UpsertRecord,
+} from './types';
+
+const ROOT_FLAG = '__root__';
+
+interface ConflictClause {
+  constraint: EnumType;
+  update_columns: EnumType[];
+}
+
+export interface GraphQLBackend {
+  healthCheck(): Promise<void>;
+
+  postQuery(query: any, variables?: any): Promise<any>;
+}
+
+interface WriteOp {
+  readonly query: any;
+  readonly errorMsg: string;
+}
+
+interface UpsertOp {
+  readonly query: any;
+  readonly upsertsByKey: Map<string, Upsert[]>;
+  readonly isRoot: boolean;
+}
+
+export interface Upsert {
+  id?: string; // will be set after object is inserted
+  readonly model: string;
+  readonly object: Dictionary<any>;
+  readonly foreignKeys: Dictionary<Upsert>;
+}
+
+interface UpsertResult {
+  readonly model: string;
+  readonly numObjects: number;
+  readonly durationMs: number;
+}
+
+export class UpsertBuffer {
+  private readonly upsertBuffer: Map<string, Upsert[]> = new Map();
+
+  add(upsert: Upsert): void {
+    const modelBuffer = this.upsertBuffer.get(upsert.model);
+    if (!modelBuffer) {
+      this.upsertBuffer.set(upsert.model, [upsert]);
+      return;
+    }
+    modelBuffer.push(upsert);
+  }
+
+  size(): number {
+    // the limiting factor is size of a single request
+    return Array.from(this.upsertBuffer.values()).reduce(
+      (acc, arr) => max([acc, arr.length]) ?? acc,
+      0
+    );
+  }
+
+  pop(model: string): Upsert[] | undefined {
+    return this.getInternal(model, true);
+  }
+
+  get(model: string): Upsert[] | undefined {
+    return this.getInternal(model, false);
+  }
+
+  private getInternal(model: string, remove: boolean): Upsert[] | undefined {
+    if (this.upsertBuffer.has(model)) {
+      const modelUpserts = this.upsertBuffer.get(model);
+      if (remove) {
+        this.upsertBuffer.delete(model);
+      }
+      return modelUpserts;
+    }
+    return undefined;
+  }
+
+  clear(): number {
+    const size = this.size();
+    this.upsertBuffer.clear();
+    return size;
+  }
+}
+
+export function serialize(obj: Dictionary<any>): string {
+  return keys(obj)
+    .sort()
+    .map((k) => `${k}:${serializeValue(obj[k])}`)
+    .join('|');
+}
+
+export function serializeValue(obj: any): string {
+  return isObject(obj) ? serialize(obj) : String(obj);
+}
+
+/**
+ * Like lodash pick with (1) null value replacement and (2) type-aware
+ * normalization.
+ */
+export function strictPick(
+  obj: any,
+  keys: string[],
+  keyTypes: Dictionary<string> = {},
+  nullValue = 'null'
+): any {
+  function keyValue(key: string): any {
+    let rawValue = obj[key];
+    // normalize dates and string timestamps to epochs
+    if (rawValue && keyTypes[key] === 'timestamptz') {
+      rawValue = isDate(rawValue)
+        ? rawValue.getTime()
+        : isString(rawValue)
+          ? Date.parse(rawValue)
+          : rawValue;
+    }
+    return rawValue ?? nullValue;
+  }
+  return keys.reduce((result, key) => set(result, key, keyValue(key)), {});
+}
+
+/**
+ * Groups objects by primary key and then merges all related objects into
+ * a single object where last-wins for overlapping properties.
+ */
+export function mergeByPrimaryKey(
+  objects: any[],
+  primaryKeys: string[]
+): any[] {
+  const byPK = groupBy(objects, (o) => serialize(pick(o, primaryKeys)));
+  return Object.values(byPK).map((arr) =>
+    arr.reduce((acc, obj) => ({...acc, ...obj}), {})
+  );
+}
+
+/**
+ * Execute async callback for each batch of upserts.
+ */
+export function batchIterator<T>(
+  batches: Upsert[][],
+  callback: (batch: Upsert[]) => Promise<T>
+): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<T> {
+      for (const batch of batches) {
+        yield await callback(batch);
+      }
+    },
+  };
+}
+
+/**
+ * Separates objects into arrays of objects
+ * that all have the same keys.
+ */
+export function groupByKeys(objects: any[]): any[][] {
+  const byObjKeyNames: Dictionary<any[]> = groupBy(objects, (obj) =>
+    Object.keys(obj).sort().join('|')
+  );
+  return Object.values(byObjKeyNames);
+}
+
+/**
+ * Separates upserts into levels. Level 0 has no dependencies on other levels.
+ * Level 1 depends on Level 0, 2 on 1 and so on.
+ */
+export function toLevels(upserts: Upsert[]): Upsert[][] {
+  const withLevel: [Upsert, number][] = flatMap(upserts, (u) => addLevel(u));
+  const byLevel: Dictionary<[Upsert, number][]> = groupBy(
+    withLevel,
+    (tuple) => tuple[1]
+  );
+  const result: any[] = [];
+  Object.keys(byLevel)
+    .sort()
+    .forEach((level) => {
+      result.push(unzip(byLevel[level])[0]);
+    });
+  return result;
+}
+
+/**
+ * Converts an Upsert (which is a tree structure) into an array of tuples.
+ * Each tuple contains an Upsert and its level in the tree structure.
+ * The level indicates the number of steps from a leaf where leaves are level 0.
+ * If an Upsert has multiple paths to a leaf, the level is the maximum number of
+ * steps.
+ */
+function addLevel(u: Upsert): [Upsert, number][] {
+  const result: [Upsert, number][] = [];
+  let maxAncestorLevel = 0;
+  for (const ancestor of Object.values(u.foreignKeys)) {
+    if (ancestor.model === u.model) {
+      const ancestorsWithLevels = addLevel(ancestor);
+      maxAncestorLevel = Math.max(ancestorsWithLevels[0][1], maxAncestorLevel);
+      result.push(...ancestorsWithLevels);
+    }
+  }
+  const thisLevel = result.length ? maxAncestorLevel + 1 : 0;
+  result.unshift([u, thisLevel]);
+  return result;
+}
+
+export function toPostgresArrayLiteral(value: any[]): string {
+  return `{${value
+    .map((s) => {
+      if (typeof s === 'string') {
+        return `"${s}"`;
+      }
+      if (isNil(s)) {
+        return 'NULL';
+      }
+      return s;
+    })
+    .join(',')}}`;
+}
+
+/**
+ * Client for writing records as GraphQL mutations.  The client supports 3
+ * kinds of writes: Upserts, Updates and Deletes.
+ *
+ * For upserts (when upsertBatchSize is greater than 0), the high-level
+ * algorithm is:
+ *
+ * > For each record, build a tree of Upserts. The tree has more than one node
+ * if the current record represents a
+ *   nested entity (e.g. branch record referencing repo which, in-turn,
+ *   references org).
+ * > Buffer Upserts and index each by model (e.g. vcs_Branch)
+ * > When batch size limit is reached, execute a single insert mutation per
+ * model. Start with leaves of Upsert tree.
+ * > After inserting a batch, copy the id of each record back to the Upsert
+ * object. When inserting subsequent batches,
+ *   required foreign keys will be read from the Upsert tree and copied to
+ *   the appropriate batch mutation.
+ *
+ * Note: there is a complication in this algorithm for self-referent models
+ * (i.e. org_Employee's manager relationship).
+ * For these models, we split the batch into "levels". The first level consists
+ * of records with no dependencies on
+ * records of the same type. The second depends on the first and so on.
+ *
+ * For Updates and Deletes (which are much less frequent) we have a separate
+ * write buffer.  This buffer is
+ * flushed if it reaches capacity.  There is no attempt to combine these into
+ * bulk mutations (as done w/ upserts).
+ */
+export class GraphQLClient {
+  private readonly logger: Logger;
+  private readonly schemaLoader: SchemaLoader;
+  private readonly backend: GraphQLBackend;
+  private schema: Schema | undefined;
+  private tableNames: Set<string> | undefined;
+  private tableDependencies: string[] | undefined;
+  private supportsSetCtx = false;
+  private readonly mutationBatchSize: number;
+  private readonly upsertBatchSize: number;
+  private readonly writeBuffer: WriteOp[] = [];
+  private readonly upsertBuffer = new UpsertBuffer();
+  private readonly selfReferentModels = new Set();
+  private readonly updateResetLimit: boolean;
+  private readonly resetPageSize: number;
+  private resetLimitMillis: number;
+
+  constructor(
+    logger: pino.Logger,
+    schemaLoader: SchemaLoader,
+    backend: GraphQLBackend,
+    upsertBatchSize: number,
+    mutationBatchSize: number,
+    updateResetLimit = true,
+    resetPageSize = 500
+  ) {
+    this.logger = logger;
+    this.schemaLoader = schemaLoader;
+    this.backend = backend;
+    this.upsertBatchSize = upsertBatchSize ?? 10000;
+    this.mutationBatchSize = mutationBatchSize ?? 100;
+    this.resetPageSize = resetPageSize;
+    assert(
+      this.upsertBatchSize >= 0,
+      `negative upsert batch size: ${this.upsertBatchSize}`
+    );
+    assert(
+      this.mutationBatchSize > 0,
+      `non-positive mutation batch size: ${this.mutationBatchSize}`
+    );
+    assert(
+      this.resetPageSize > 0,
+      `non-positive reset page size: ${this.resetPageSize}`
+    );
+    this.updateResetLimit = updateResetLimit;
+    this.resetLimitMillis = updateResetLimit
+      ? // January 1, 2200
+        7258118400000
+      : Date.now();
+  }
+
+  async healthCheck(): Promise<void> {
+    try {
+      await this.backend.healthCheck();
+    } catch (e: any) {
+      throw new VError(e, 'Failed to check graphql backend health');
+    }
+  }
+
+  async loadSchema(): Promise<void> {
+    this.schema = await this.schemaLoader.loadSchema();
+    // various derivative values of schema
+    this.tableNames = new Set(this.getSchema().tableNames);
+    // check if we have setCtx mutation available based on presence of its
+    // result table
+    this.supportsSetCtx = this.tableNames.has('set_ctx_result');
+    this.tableDependencies = [...this.getSchema().sortedModelDependencies];
+    reverse(this.tableDependencies);
+    // self-referent models
+    for (const [model, modelRefs] of
+      Object.entries(this.getSchema().references)) {
+      for (const reference of Object.values(modelRefs)) {
+        if (reference.model === model) {
+          this.selfReferentModels.add(model);
+        }
+      }
+    }
+  }
+
+  private getSchema(): Schema {
+    if (!this.schema) {
+      throw new VError(
+        'Schema is not initialized. Please call loadSchema first.'
+      );
+    }
+    return this.schema;
+  }
+
+  async resetData(
+    originProvider: OriginProvider,
+    models: ReadonlyArray<string>,
+    isResetSync: boolean,
+    keepReferencedRecords: boolean
+  ): Promise<void> {
+    const schema = this.getSchema();
+
+    // ensure deletes are executed after processing records
+    await this.flush();
+
+    const minRefreshedAt = new Date(this.resetLimitMillis).toISOString();
+    const deleteSessionId = randomUUID().toString();
+    const sessionInfo = this.supportsSetCtx
+      ? ` with session id ${deleteSessionId}`
+      : '';
+    const origin = originProvider.getOrigin();
+    const bucketedOriginPattern =
+      `${origin}${StreamNameSeparator}bucket${StreamNameSeparator}`;
+    this.logger.info(
+      `Resetting data before ${minRefreshedAt} for origin` +
+      ` ${origin}${sessionInfo}`
+    );
+    if (isResetSync) {
+      this.logger.info(
+        'Also resetting data for bucketed origins ' +
+        `(matching ${bucketedOriginPattern}<number>)`
+      );
+    }
+
+    const originFilter = isResetSync
+      ? {
+          _or: [
+            {origin: {_eq: origin}},
+            {
+              origin: {
+                _like: `${bucketedOriginPattern}%`,
+              },
+            },
+          ],
+        }
+      : {origin: {_eq: origin}};
+
+    for (const model of intersection(
+      schema.sortedModelDependencies,
+      models
+    )) {
+      this.logger.info(`Resetting ${model} data`);
+      const deleteConditions: any = {
+        refreshedAt: {_lt: minRefreshedAt},
+        ...originFilter,
+      };
+      if (keepReferencedRecords) {
+        deleteConditions._not = {
+          _or: schema.backReferences[model].map((br) => {
+            return {
+              [br.field]: {},
+            };
+          }),
+        };
+      }
+      const query = {
+        [model]: {
+          __args: {
+            where: {
+              _and: {...deleteConditions},
+            },
+          },
+          id: true,
+        },
+      };
+      const records = paginateQuery(
+        jsonToGraphQLQuery({query}),
+        (query, args) =>
+          this.backend.postQuery(query, args).then((res) => res?.data),
+        this.resetPageSize
+      );
+      let ids = [];
+      for await (const record of records) {
+        ids.push(record.id);
+        // delete in batches
+        if (ids.length >= this.resetPageSize) {
+          await this.deleteById(model, ids, deleteSessionId);
+          ids = [];
+        }
+      }
+      // clean up any remaining records
+      if (ids.length > 0) {
+        await this.deleteById(model, ids, deleteSessionId);
+      }
+    }
+  }
+
+  async deleteById(
+    model: string,
+    ids: string[],
+    session: string
+  ): Promise<void> {
+    const ctxExpr = this.supportsSetCtx ?
+      `ctx: setCtx(args: {session: "${session}"}) { success }`
+      : '';
+    const query = `mutation {
+      ${ctxExpr}
+      del: delete_${model}(where:{id: {_in:[
+        ${ids.map((id) => `"${id}"`).join(',')}
+      ]}}) {
+        affected_rows
+      }
+    }`;
+    await this.backend.postQuery(query);
+  }
+
+  async writeRecord(
+    model: string,
+    record: Dictionary<any>,
+    origin: string
+  ): Promise<void> {
+    this.getSchema();
+    if (!this.tableNames?.has(model)) {
+      throw new VError(`Table ${model} does not exist`);
+    }
+    if (this.upsertBatchSize) {
+      this.addUpsert(model, record, origin);
+      if (this.upsertBuffer.size() >= this.upsertBatchSize) {
+        await this.flushUpsertBuffer();
+      }
+    } else {
+      const obj = this.createMutationObject(model, record, origin);
+      const mutation = {
+        [`insert_${model}_one`]: {__args: obj, id: true, refreshedAt: true},
+      };
+      await this.postQuery({mutation}, `Failed to write ${model} record`);
+    }
+  }
+
+  private async flushUpsertBuffer(): Promise<void> {
+    try {
+      await this.doFlushUpsertBuffer();
+    } catch (e: any) {
+      const numRemoved = this.upsertBuffer.clear();
+      throw new VError(
+        e,
+        'failed to flush upsert buffer. abandoned %d records',
+        numRemoved
+      );
+    }
+  }
+
+  private async execUpsert(model: string, op: UpsertOp): Promise<UpsertResult> {
+    // write batch
+    const opGql = jsonToGraphQLQuery(op.query);
+    const start = Date.now();
+    const opRes = await this.backend.postQuery(opGql);
+    const end = Date.now();
+    // extract ids of newly written records and set on upserts.
+    // the ids are used as foreign keys by subsequent batches
+    // step 1: access array of results
+    // will be at path 'opRes.data.insert_<model>.returning'
+    const paths = keys(opRes.data);
+    assert(paths.length === 1, `expected one element in ${paths}`);
+    const objects = get(opRes.data, `${paths[0]}.returning`);
+    assert(Array.isArray(objects), 'expected array');
+    for (const obj of objects) {
+      // step 2: assign id to all upserts related to this object
+      // construct key from returned result and lookup upsert by key
+      const key = this.serializedPrimaryKey(model, obj);
+      const upserts = op.upsertsByKey.get(key);
+      assert(upserts, `failed to resolve upserts for ${model} and ${key}`);
+      assert(
+        obj.id,
+        `failed to resolve id for ${model} and ${JSON.stringify(obj)}`
+      );
+      upserts.forEach((u) => (u.id = obj.id));
+
+      if (this.updateResetLimit && op.isRoot) {
+        const recordRefreshedAtMs = new Date(obj.refreshedAt).getTime();
+        this.resetLimitMillis = Math.min(
+          recordRefreshedAtMs,
+          this.resetLimitMillis
+        );
+      }
+    }
+    return {
+      model,
+      numObjects: objects.length,
+      durationMs: end - start,
+    };
+  }
+
+  private async doFlushUpsertBuffer(): Promise<void> {
+    assert(this.tableDependencies);
+    for (const model of this.tableDependencies) {
+      const modelUpserts = this.upsertBuffer.pop(model);
+      if (modelUpserts) {
+        const withLevels = this.selfReferentModels.has(model)
+          ? toLevels(modelUpserts)
+          : [modelUpserts];
+        const iterator: AsyncIterable<UpsertResult[]> = batchIterator(
+          withLevels,
+          (batch) => {
+            const ops = this.toUpsertOps(model, batch);
+            return Promise.all(ops.map((op) => this.execUpsert(model, op)));
+          }
+        );
+        try {
+          for await (const results of iterator) {
+            for (const result of results) {
+              this.logger.debug(
+                `Executed ${model} upsert with ${result.numObjects} ` +
+                `object(s) in ${result.durationMs}ms`,
+              );
+            }
+          }
+        } catch (e: any) {
+          throw new VError(e, `failed to write upserts for ${model}`);
+        }
+      }
+    }
+  }
+
+  async writeTimestampedRecord(record: TimestampedRecord): Promise<void> {
+    switch (record.operation) {
+      case Operation.UPSERT:
+        await this.writeRecord(
+          record.model,
+          (record as UpsertRecord).data,
+          record.origin
+        );
+        break;
+      case Operation.UPDATE:
+        await this.writeUpdateRecord(record as UpdateRecord);
+        break;
+      case Operation.DELETION:
+        await this.writeDeletionRecord(record as DeletionRecord);
+        break;
+      default:
+        throw new VError(
+          `Unsupported operation ${record.operation} for ${record}`
+        );
+    }
+  }
+
+  private async writeUpdateRecord(record: UpdateRecord): Promise<void> {
+    const upsertRec = {
+      ...record.where,
+      ...pick(record.patch, record.mask),
+    };
+    const obj = this.createMutationObject(
+      record.model,
+      upsertRec,
+      record.origin,
+      true
+    );
+    const mutation = {
+      [`insert_${record.model}_one`]: {__args: obj, id: true},
+    };
+    await this.postQuery({mutation}, `Failed to update ${record.model} record`);
+  }
+
+  private async writeDeletionRecord(record: DeletionRecord): Promise<void> {
+    const mutation = {
+      [`delete_${record.model}`]: {
+        __args: {
+          where: this.createWhereClause(record.model, record.where),
+        },
+        affected_rows: true,
+      },
+    };
+    await this.postQuery({mutation}, `Failed to delete ${record.model} record`);
+  }
+
+  private async postQuery(query: any, errorMsg: string): Promise<void> {
+    this.writeBuffer.push({
+      query,
+      errorMsg,
+    });
+    if (this.writeBuffer.length >= this.mutationBatchSize) {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    // sequentially flush upsert then write buffer
+    // we do this sequentially because we may have updates
+    // that operate on records in the upsert buffers and
+    // therefore need the upserts written first
+    await this.flushUpsertBuffer();
+    await this.flushWriteBuffer();
+  }
+
+  private async flushWriteBuffer(): Promise<void> {
+    const queries = this.writeBuffer.map((op) => op.query);
+    const gql = GraphQLClient.batchMutation(queries);
+    if (gql) {
+      const res = await this.backend.postQuery(gql);
+      if (res.errors) {
+        this.logger.warn(
+          `Error while saving batch: ${JSON.stringify(
+            res.errors
+          )}. Query: ${gql}`
+        );
+        // now try mutations individually and fail on the first bad one
+        for (const op of this.writeBuffer) {
+          const opGql = jsonToGraphQLQuery(op.query);
+          const opRes = await this.backend.postQuery(opGql);
+          this.writeBuffer.shift();
+          if (opRes.errors) {
+            throw new VError(
+              `${op.errorMsg} with query '${opGql}': ${JSON.stringify(
+                opRes.errors
+              )}`
+            );
+          }
+        }
+      } else {
+        // res.data is expected to have one object with 'id' and
+        //  'refreshedAt' for each of the mutations
+        // {
+        //   "m0": {
+        //     "id": ...,
+        //     "refreshedAt": ...
+        //   },
+        //   "m1": {
+        //     "id": ...,
+        //     "refreshedAt": ...
+        //   },
+        //   ...
+        // }
+        if (this.updateResetLimit) {
+          for (const mutationRes of Object.values(res.data)) {
+            const refreshedAt = get(mutationRes, 'refreshedAt');
+            if (refreshedAt) {
+              const recordRefreshedAtMs = new Date(refreshedAt).getTime();
+              this.resetLimitMillis = Math.min(
+                recordRefreshedAtMs,
+                this.resetLimitMillis
+              );
+            }
+          }
+        }
+
+        // truncate the buffer
+        this.writeBuffer.splice(0);
+      }
+    }
+  }
+
+  /**
+   * Constructs a gql query from an array of json mutations.
+   * The outputted qql mutation might look like:
+   *
+   *   mutation  {
+   *     i1: insert_cicd_Artifact_one(object: {uid: "u1b"}) {
+   *       id
+   *       refreshedAt
+   *     }
+   *     i2: insert_cicd_Artifact_one(object: {uid: "u2b"}) {
+   *       id
+   *       refreshedAt
+   *     }
+   *   }
+   *
+   *  Notable here are the i1/i2 aliases.  These are required when multiple
+   *  operations
+   *  share the same name (e.g. insert_cicd_Artifact_one) and are supported in
+   *  jsonToGraphQLQuery with __aliasFor directive.
+   *
+   *  @return batch gql mutation or undefined if the input is undefined, empty
+   *  or doesn't contain any mutations.
+   */
+  static batchMutation(queries: any[]): string | undefined {
+    if (queries && queries.length > 0) {
+      const queryObj: any = {};
+      queries.forEach((query, idx) => {
+        if (query.mutation) {
+          const queryType = Object.keys(query.mutation)[0];
+          const queryBody = query.mutation[queryType];
+          queryObj[`m${idx}`] = {
+            __aliasFor: queryType,
+            ...queryBody,
+          };
+        }
+      });
+      if (Object.keys(queryObj).length > 0) {
+        return jsonToGraphQLQuery({mutation: queryObj});
+      }
+    }
+    return undefined;
+  }
+
+  private createWhereClause(
+    model: string,
+    record: Dictionary<any>
+  ): Dictionary<any> {
+    const obj: any = {};
+    for (const [field, value] of Object.entries(record)) {
+      const nestedModel = this.getSchema().references[model][field];
+      if (nestedModel && value) {
+        obj[nestedModel.field] = this.createWhereClause(
+          nestedModel.model,
+          value
+        );
+      } else {
+        const val = this.formatFieldValue(model, field, value);
+        if (val) {
+          obj[field] = {_eq: val};
+        }
+      }
+    }
+    return obj;
+  }
+
+  private createMutationObject(
+    model: string,
+    record: Dictionary<any>,
+    origin?: string,
+    keepExistingOrigin?: boolean,
+    nested?: boolean
+  ): {
+    data?: Dictionary<any>;
+    object?: Dictionary<any>;
+    on_conflict: Dictionary<any>;
+  } {
+    const obj: any = {};
+    const foreignKeys = [];
+    for (const [field, value] of Object.entries(record)) {
+      const nestedModel = this.getSchema().references[model][field];
+      if (nestedModel && value) {
+        foreignKeys.push(nestedModel.foreignKey);
+        obj[nestedModel.field] = this.createMutationObject(
+          nestedModel.model,
+          value,
+          undefined,
+          keepExistingOrigin,
+          true
+        );
+      } else {
+        const val = this.formatFieldValue(model, field, value);
+        if (!isNil(val)) {
+          obj[field] = val;
+        }
+      }
+    }
+    if (origin) {
+      obj.origin = origin;
+    }
+    const updateFieldMask = new Set(Object.keys(obj).concat(foreignKeys));
+    if (keepExistingOrigin) {
+      updateFieldMask.delete('origin');
+    }
+    return {
+      [nested ? 'data' : 'object']: obj,
+      on_conflict: this.createConflictClause(model, nested, updateFieldMask),
+    };
+  }
+
+  private addUpsert(
+    model: string,
+    record: Dictionary<any>,
+    origin?: string
+  ): Upsert {
+    const object: any = {};
+    const foreignKeys: Dictionary<Upsert> = {};
+    for (const [field, value] of Object.entries(record)) {
+      const nestedModel = this.getSchema().references[model][field];
+      if (nestedModel) {
+        if (isNil(value)) {
+          // for explicit nil relation, set the FK of this record to null
+          object[nestedModel.foreignKey] = null;
+        } else {
+          foreignKeys[field] = this.addUpsert(nestedModel.model, value);
+        }
+      } else if (this.isValidField(model, field)) {
+        const val = this.formatFieldValue(model, field, value);
+        object[field] = isNil(val) ? null : val;
+      }
+    }
+    if (origin) {
+      object.origin = origin;
+      // add root flag to top-level objects
+      object[ROOT_FLAG] = true;
+    }
+    // since all our uids are non-null, check for nil uids early
+    // to prevent losing an entire batch later with db constraint
+    // error on flush
+    if (has(object, 'uid') && isNil(object.uid)) {
+      throw new VError(
+        'cannot upsert null or undefined uid for model %s with keys %s',
+        model,
+        JSON.stringify(pick(record, this.getSchema().primaryKeys[model]))
+      );
+    }
+    const upsert = {
+      model,
+      object,
+      foreignKeys,
+    };
+    // index by model
+    this.upsertBuffer.add(upsert);
+    return upsert;
+  }
+
+  private objectWithForeignKeys(upsert: Upsert): Dictionary<any> {
+    if (isEmpty(upsert.foreignKeys)) {
+      return upsert.object;
+    }
+    // for each FK, copy id of related upsert to FK field
+    // the upsert's id was populated after the associated batch
+    // was written in doFlushUpsertBuffer
+    const result = clone(upsert.object);
+    for (const [relName, fkUpsert] of Object.entries(upsert.foreignKeys)) {
+      // foreign key was constructed from schema so the following is safe
+      const fkField = this.getSchema()
+        .references[upsert.model][relName].foreignKey;
+      const fkValue = fkUpsert.id;
+      assert(
+        !isNil(fkValue),
+        `failed to resolve fk value for ${relName} from ${JSON.stringify(
+          fkUpsert
+        )}`
+      );
+      result[fkField] = fkValue;
+    }
+    return result;
+  }
+
+  /**
+   * returns serialized version of keys fields
+   */
+  private serializedPrimaryKey(model: string, obj: any): string {
+    const keyObj = strictPick(
+      obj,
+      this.getSchema().primaryKeys[model],
+      this.getSchema().scalars[model]
+    );
+    return serialize(keyObj);
+  }
+
+  private toUpsertOps(model: string, modelUpserts: Upsert[]): UpsertOp[] {
+    // shared among all the results of this method
+    const upsertsByKey = new Map();
+    // add FKs and index upsert by primary key
+    // the index is needed after write to find source
+    // upsert and set id
+    const all = modelUpserts.map((u) => {
+      const fullObj = this.objectWithForeignKeys(u);
+      const key = this.serializedPrimaryKey(model, fullObj);
+      const upsertsForKey = upsertsByKey.get(key);
+      if (!upsertsForKey) {
+        upsertsByKey.set(key, [u]);
+      } else {
+        upsertsForKey.push(u);
+      }
+      return fullObj;
+    });
+    const primaryKeys = this.getSchema().primaryKeys[model];
+    // there can be multiple records that represent the
+    // same object.  merge all records into one
+    const allObjects = mergeByPrimaryKey(all, primaryKeys);
+    const keysObj = primaryKeys
+      .sort()
+      .reduce((a, v) => ({...a, [v]: true}), {});
+    // for each set of unique keys, build an UpsertOp
+    const groups = groupByKeys(allObjects);
+    return groups.map((objects) => {
+      assert(objects?.length, 'objects should not be empty');
+      // all objects have same fields due to groupByKeys call
+      // pull out fields of first as mask for update fields to ensure
+      // fields that aren't in the data are not modified by the upsert
+      const updateColumnMask = new Set(Object.keys(objects[0]));
+      // determine if this group contains root objects
+      let isRoot = false;
+      if (has(objects[0], ROOT_FLAG)) {
+        isRoot = true;
+        // remove root flag from all objects
+        objects.forEach((o) => delete o[ROOT_FLAG]);
+      }
+      const onConflict = this.createUpsertConflictClause(
+        model,
+        updateColumnMask,
+        isRoot
+      );
+      const mutation = {
+        mutation: {
+          [`insert_${model}`]: {
+            __args: {
+              // sort objects to avoid deadlocks on concurrent inserts
+              objects: orderBy(objects, primaryKeys),
+              on_conflict: onConflict,
+            },
+            returning: {
+              id: true,
+              refreshedAt: true,
+              ...keysObj,
+            },
+          },
+        },
+      };
+      return {
+        query: mutation,
+        upsertsByKey,
+        isRoot,
+      };
+    });
+  }
+
+  private isValidField(model: string, field: string): boolean {
+    return has(this.getSchema().scalars[model], field);
+  }
+
+  private formatFieldValue(model: string, field: string, value: any): any {
+    if (isNil(value)) {
+      return undefined;
+    }
+    if (!this.isValidField(model, field)) {
+      this.logger.debug(`Could not find type of ${field} in ${model}`);
+      return undefined;
+    }
+    const type = this.getSchema().scalars[model][field];
+    if (type === 'timestamptz') {
+      // The field value may already be a string.
+      // E.g., if coming from the Faros Feeds source.
+      return typeof value === 'string' ? value : timestamptz(value);
+    } else if (type.startsWith('_') && typeof value !== 'string') {
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `expected array for ${model}.${field} of type ${type}. ` +
+          `Received: ${JSON.stringify(
+            value,
+          )}`,
+        );
+      }
+      // format array value as postgres literal
+      return toPostgresArrayLiteral(value);
+    } else if (typeof value === 'object' || Array.isArray(value)) {
+      return traverse(value).map(function (this, val) {
+        if (val instanceof Date) {
+          this.update(val.getTime());
+        }
+      });
+    }
+    return value;
+  }
+
+  private createConflictClause(
+    model: string,
+    nested?: boolean,
+    updateFieldMask?: Set<string>
+  ): ConflictClause {
+    const updateColumns = nested
+      ? []
+      : difference(
+          Object.keys(this.getSchema().scalars[model]),
+          this.getSchema().primaryKeys[model]
+        );
+    const filteredUpdateFields =
+      updateFieldMask && !nested
+        ? updateColumns.filter((c) => updateFieldMask.has(c))
+        : updateColumns;
+    // if empty, use model keys to ensure queries always return results
+    if (isEmpty(filteredUpdateFields)) {
+      filteredUpdateFields.push(...this.getSchema().primaryKeys[model]);
+    }
+    return {
+      constraint: new EnumType(`${model}_pkey`),
+      update_columns: filteredUpdateFields.map((c) => new EnumType(c)),
+    };
+  }
+
+  private createUpsertConflictClause(
+    model: string,
+    updateFieldMask: Set<string>,
+    isRoot: boolean
+  ): ConflictClause {
+    // superset of fields that can be updated
+    const updateColumns = difference(
+      Object.keys(this.getSchema().scalars[model]),
+      this.getSchema().primaryKeys[model]
+    );
+    // filter to only those fields that are in the data
+    const filteredUpdateFields = updateColumns.filter((c) =>
+      updateFieldMask.has(c)
+    );
+    // for root objects, always update refreshedAt
+    if (isRoot) {
+      filteredUpdateFields.push('refreshedAt');
+    }
+    // if empty, use model keys to ensure queries always return results
+    if (isEmpty(filteredUpdateFields)) {
+      filteredUpdateFields.push(...this.getSchema().primaryKeys[model]);
+    }
+    return {
+      constraint: new EnumType(`${model}_pkey`),
+      update_columns: filteredUpdateFields.map((c) => new EnumType(c)),
+    };
+  }
+}
+
+function timestamptz(date: Date): string {
+  return dateformat.asString(dateformat.ISO8601_WITH_TZ_OFFSET_FORMAT, date);
+}
+
+function paginateQuery(
+  rawQuery: string,
+  client: (query: string, args: any) => Promise<any>,
+  pageSize = 1000,
+  args: Map<string, any> = new Map<string, any>()
+): AsyncIterable<any> {
+  const {query, edgesPath, edgeIdPath} = paginatedQueryV2(rawQuery);
+  assert(edgesPath && edgeIdPath);
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<any> {
+      let id = '';
+      let hasNextPage = true;
+      while (hasNextPage) {
+        const data = await client(query, {
+          limit: pageSize,
+          id,
+          ...Object.fromEntries(args.entries()),
+        });
+        const edges = get(data, edgesPath) || [];
+        for (const edge of edges) {
+          id = get(edge, edgeIdPath);
+          unset(edge, edgeIdPath);
+          if (!id) {
+            return;
+          }
+          yield edge;
+        }
+        // break on partial page
+        hasNextPage = edges.length === pageSize;
+      }
+    },
+  };
+}

--- a/src/graphql/client/graphql-client.ts
+++ b/src/graphql/client/graphql-client.ts
@@ -23,16 +23,13 @@ import {
   unset,
   unzip,
 } from 'lodash';
-import pino from 'pino';
 import traverse from 'traverse';
 import {assert, Dictionary} from 'ts-essentials';
 import {VError} from 'verror';
 
-//import {AirbyteLogger} from 'faros-airbyte-cdk';
 import {paginatedQueryV2} from '../graphql';
 import {SchemaLoader} from '../schema';
 import {Schema} from '../types';
-//import {StreamNameSeparator} from '../converters/converter';
 import {OriginProvider} from './graphql-writer';
 import {
   DeletionRecord, Logger,
@@ -214,7 +211,7 @@ export function toLevels(upserts: Upsert[]): Upsert[][] {
   );
   const result: any[] = [];
   Object.keys(byLevel)
-    .sort()
+    .sort((a, b) => Number(a) - Number(b))
     .forEach((level) => {
       result.push(unzip(byLevel[level])[0]);
     });
@@ -305,7 +302,7 @@ export class GraphQLClient {
   private resetLimitMillis: number;
 
   constructor(
-    logger: pino.Logger,
+    logger: Logger,
     schemaLoader: SchemaLoader,
     backend: GraphQLBackend,
     upsertBatchSize: number,

--- a/src/graphql/client/graphql-writer.ts
+++ b/src/graphql/client/graphql-writer.ts
@@ -1,0 +1,90 @@
+import {sortBy} from 'lodash';
+import {Dictionary} from 'ts-essentials';
+import {VError} from 'verror';
+
+import {GraphQLClient} from './graphql-client';
+import {Operation, TimestampedRecord} from './types';
+import {WriteStats} from './write-stats';
+
+interface RecordProcessorHandler {
+  handleRecordProcessingError: (
+    stats: WriteStats,
+    processRecord: () => Promise<void>
+  ) => Promise<void>;
+}
+
+export interface OriginProvider {
+  getOrigin: (record?: Dictionary<any>) => string;
+}
+
+export class GraphQLWriter {
+  private readonly timestampedRecords: TimestampedRecord[] = [];
+
+  constructor(
+    private readonly graphQLClient: GraphQLClient,
+    private readonly originProvider: OriginProvider,
+    private readonly stats: WriteStats,
+    private readonly recordProcessorHandler: RecordProcessorHandler
+  ) {}
+
+  async write(result: any): Promise<boolean> {
+    const [baseModel, operation] = (result.model as string).split('__', 2);
+
+    if (!operation) {
+      await this.graphQLClient.writeRecord(
+        result.model,
+        result.record,
+        this.originProvider.getOrigin(result.record)
+      );
+      return false;
+    } else if (Object.values(Operation).includes(operation as Operation)) {
+      if (operation === Operation.FLUSH) {
+        await this.graphQLClient.flush();
+        return true;
+      }
+
+      const timestampedRecord: TimestampedRecord = {
+        ...result.record,
+        model: baseModel,
+        operation,
+        origin: this.originProvider.getOrigin(result.record),
+      };
+
+      // It's ok to submit non-timestamped record deletions while submitting
+      // upserts. Non-timestamped record updates are not safe here because the
+      // stream responsible for upserting the record-to-be-updated may not have
+      // been processed yet.
+      if (operation === Operation.DELETION && !result.record.at) {
+        await this.writeTimestampedRecord(timestampedRecord);
+        if (result.record.flushRequired ?? true) {
+          await this.graphQLClient.flush();
+        }
+      } else {
+        this.timestampedRecords.push(timestampedRecord);
+      }
+      return true;
+    }
+    throw new VError(
+      `Unsupported model operation ${operation} for ` +
+      `${result.model}: ${result.record}`,
+    );
+  }
+
+  async end(): Promise<void> {
+    for (const record of sortBy(this.timestampedRecords, (r) => r.at)) {
+      await this.recordProcessorHandler.handleRecordProcessingError(
+        this.stats,
+        async () => await this.writeTimestampedRecord(record)
+      );
+    }
+    await this.graphQLClient.flush();
+  }
+
+  private async writeTimestampedRecord(
+    record: TimestampedRecord
+  ): Promise<void> {
+    await this.graphQLClient.writeTimestampedRecord(record);
+    this.stats.recordsWritten++;
+    this.stats.incrementWrittenByModel(`${record.model}__${record.operation}`);
+  }
+}

--- a/src/graphql/client/types.ts
+++ b/src/graphql/client/types.ts
@@ -1,0 +1,40 @@
+import {Dictionary} from 'ts-essentials';
+
+export const StreamNameSeparator = '__';
+
+export enum Operation {
+  UPSERT = 'Upsert',
+  UPDATE = 'Update',
+  DELETION = 'Deletion',
+  FLUSH = 'Flush',
+}
+
+export interface TimestampedRecord {
+  model: string;
+  origin: string;
+  at: number;
+  operation: Operation;
+}
+
+export interface UpsertRecord extends TimestampedRecord {
+  operation: Operation.UPSERT;
+  data: Dictionary<any>;
+}
+
+export interface UpdateRecord extends TimestampedRecord {
+  operation: Operation.UPDATE;
+  where: Dictionary<any>;
+  mask: string[];
+  patch: Dictionary<any>;
+}
+
+export interface DeletionRecord extends TimestampedRecord {
+  operation: Operation.DELETION;
+  where: Dictionary<any>;
+}
+
+export interface Logger {
+  info: (msg: string) => void;
+  debug: (msg: string) => void;
+  warn: (msg: string) => void;
+}

--- a/src/graphql/client/write-stats.ts
+++ b/src/graphql/client/write-stats.ts
@@ -1,0 +1,64 @@
+import _ from 'lodash';
+import {Dictionary} from 'ts-essentials';
+
+import {Logger} from './types';
+
+export class WriteStats {
+  constructor(
+    public messagesRead: number = 0,
+    public recordsRead: number = 0,
+    public recordsProcessed: number = 0,
+    public recordsWritten: number = 0,
+    public recordsErrored: number = 0,
+    public recordsSkipped: number = 0,
+    public processedByStream: Dictionary<number> = {},
+    public writtenByModel: Dictionary<number> = {}
+  ) {}
+
+  incrementProcessedByStream(stream: string): void {
+    const count = this.processedByStream[stream];
+    this.processedByStream[stream] = count ? count + 1 : 1;
+  }
+
+  incrementWrittenByModel(model: string): void {
+    const count = this.writtenByModel[model];
+    this.writtenByModel[model] = count ? count + 1 : 1;
+  }
+
+  log(logger: Logger, writeMsg: 'Wrote' | 'Would write'): void {
+    logger.info(`Read ${this.messagesRead} messages`);
+    logger.info(`Read ${this.recordsRead} records`);
+    logger.info(`Processed ${this.recordsProcessed} records`);
+
+    const processed = _(this.processedByStream)
+      .toPairs()
+      .orderBy(0, 'asc')
+      .fromPairs()
+      .value();
+    logger.info(`Processed records by stream: ${JSON.stringify(processed)}`);
+
+    logger.info(`${writeMsg} ${this.recordsWritten} records`);
+    const written = _(this.writtenByModel)
+      .toPairs()
+      .orderBy(0, 'asc')
+      .fromPairs()
+      .value();
+    logger.info(`${writeMsg} records by model: ${JSON.stringify(written)}`);
+
+    logger.info(`Skipped ${this.recordsSkipped} records`);
+    logger.info(`Errored ${this.recordsErrored} records`);
+  }
+
+  asObject(): Dictionary<any> {
+    return {
+      messagesRead: this.messagesRead,
+      recordsRead: this.recordsRead,
+      recordsProcessed: this.recordsProcessed,
+      recordsWritten: this.recordsWritten,
+      recordsErrored: this.recordsErrored,
+      recordsSkipped: this.recordsSkipped,
+      processedByStream: this.processedByStream,
+      writtenByModel: this.writtenByModel,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,4 +66,5 @@ export {FarosGraphSchema} from './schema';
 export {Utils} from './utils';
 export {GraphQLClient, GraphQLBackend} from './graphql/client/graphql-client';
 export {GraphQLWriter, OriginProvider} from './graphql/client/graphql-writer';
-export {StreamNameSeparator, Logger} from './graphql/client/types';
+export {StreamNameSeparator, Logger, Operation} from './graphql/client/types';
+export {WriteStats} from './graphql/client/write-stats';

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,3 +64,6 @@ export {
 } from './graphql/graphql';
 export {FarosGraphSchema} from './schema';
 export {Utils} from './utils';
+export {GraphQLClient, GraphQLBackend} from './graphql/client/graphql-client';
+export {GraphQLWriter, OriginProvider} from './graphql/client/graphql-writer';
+export {StreamNameSeparator, Logger} from './graphql/client/types';

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: ['@stylistic/js'],
-  rules: {
-    '@stylistic/js/max-len': ['error', { code: 120 }],
-  },
-};

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ['@stylistic/js'],
+  rules: {
+    '@stylistic/js/max-len': ['error', { code: 120 }],
+  },
+};

--- a/test/__snapshots__/graphql-client.test.ts.snap
+++ b/test/__snapshots__/graphql-client.test.ts.snap
@@ -116,7 +116,7 @@ exports[`graphql-client write batch upsert resetData 2`] = `
 
 exports[`graphql-client write batch upsert resetData 3`] = `
 "mutation {
-
+      
       del: delete_vcs_Organization(where:{id: {_in:[
         "00042ddb78c1a5956320e7fbc7ca488517a9caa8","0008d73ec6b79910fcbadb7410c4d191e92ce44d","0011f5f8600d14dae163a37286aa1cd5e6bf6a71"
       ]}}) {
@@ -149,7 +149,7 @@ exports[`graphql-client write batch upsert resetData 6`] = `
 
 exports[`graphql-client write batch upsert resetData 7`] = `
 "mutation {
-
+      
       del: delete_vcs_Organization(where:{id: {_in:[
         "0017bcda1dfcf5b5c2db430849a4bf90f8c51be4","001d319806cb4e608aec2f47f3a2028c41b64321"
       ]}}) {

--- a/test/__snapshots__/graphql-client.test.ts.snap
+++ b/test/__snapshots__/graphql-client.test.ts.snap
@@ -1,0 +1,299 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graphql-client basic batch mutation 1`] = `"mutation { m0: insert_vcs_Membership_one (object: {vcs_User: {data: {uid: "ashnet16", source: "GitHub", origin: "myghsrc"}, on_conflict: {constraint: {value: "vcs_User_pkey"}, update_columns: [{value: "uid"}, {value: "source"}]}}, vcs_Organization: {data: {uid: "faros-ai", source: "GitHub", origin: "myghsrc"}, on_conflict: {constraint: {value: "vcs_Organization_pkey"}, update_columns: [{value: "uid"}, {value: "source"}]}}, origin: "myghsrc"}, on_conflict: {constraint: {value: "vcs_Membership_pkey"}, update_columns: [{value: "origin"}, {value: "refreshedAt"}]}) { id } m1: insert_vcs_User_one (object: {uid: "betafood", type: {category: "User", detail: "user"}, source: "GitHub", origin: "myghsrc"}, on_conflict: {constraint: {value: "vcs_User_pkey"}, update_columns: [{value: "email"}, {value: "name"}, {value: "origin"}, {value: "refreshedAt"}, {value: "type"}, {value: "url"}]}) { id } }"`;
+
+exports[`graphql-client write batch updates update_columns bug 1`] = `"mutation { m0: insert_tms_Task_one (object: {uid: "9", source: "jira", origin: "mytestsource"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [origin]}) { id refreshedAt } m1: insert_tms_Task_one (object: {uid: "7", source: "jira", origin: "mytestsource"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [origin]}) { id refreshedAt } m2: insert_tms_Task_one (object: {uid: "7", tms_Task: {data: {uid: "9", source: "jira"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [source, uid]}}, source: "jira", origin: "mytestsource"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [origin, parent]}) { id refreshedAt } }"`;
+
+exports[`graphql-client write batch upsert allow upsert null values 1`] = `"mutation { insert_vcs_Commit (objects: [{sha: "c2", authorId: null, message: null, origin: "mytestsource"}], on_conflict: {constraint: vcs_Commit_pkey, update_columns: [authorId, message, origin, refreshedAt]}) { returning { id refreshedAt repositoryId sha } } }"`;
+
+exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: "faros-ai", source: "GitHub"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: "hermes", organizationId: "t1|gql-e2e-v2|GitHub|faros-ai"}, {name: "metis", organizationId: "t1|gql-e2e-v2|GitHub|faros-ai"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;
+
+exports[`graphql-client write batch upsert basic end-to-end 3`] = `"mutation { insert_vcs_Branch (objects: [{name: "foo", origin: "mytestsource", repositoryId: "t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai"}, {name: "main", origin: "mytestsource", repositoryId: "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt name repositoryId } } }"`;
+
+exports[`graphql-client write batch upsert mergeByPrimaryKey - object value 1`] = `
+[
+  {
+    "origin": "c1d1-2",
+    "type": {
+      "category": "c1",
+      "detail": "d1",
+    },
+    "uid": "tovbinm",
+  },
+  {
+    "origin": "c1d2",
+    "type": {
+      "category": "c1",
+      "detail": "d2",
+    },
+    "uid": "tovbinm",
+  },
+]
+`;
+
+exports[`graphql-client write batch upsert mergeByPrimaryKey 1`] = `
+[
+  {
+    "htmlUrl": "https://github.com/tovbinm",
+    "name": "tovbinm",
+    "origin": "mytestsource2",
+    "source": "GitHub",
+    "type": {
+      "category": "User",
+      "detail": "user",
+    },
+    "uid": "tovbinm",
+  },
+  {
+    "htmlUrl": "https://github.com/vitalyg",
+    "name": "vitalyg",
+    "origin": "mytestsource",
+    "source": "GitHub",
+    "type": {
+      "foo": "bar",
+    },
+    "uid": "vitalyg",
+  },
+  {
+    "name": "vitality",
+    "origin": "mytestsource",
+    "source": null,
+    "type": {
+      "foo": "bar",
+    },
+    "uid": "vitalyg",
+  },
+  {
+    "email": "some-email",
+    "htmlUrl": "https://github.com/jeniii",
+    "name": "some-name",
+    "uid": "jeniii",
+  },
+]
+`;
+
+exports[`graphql-client write batch upsert nil uid 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: "u1", origin: "mytestsource"}, {uid: "u2", origin: "mytestsource"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: "faros-ai", source: "GitHub"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 2`] = `"mutation { insert_vcs_Repository (objects: [{name: "hermes", organizationId: "t1|gql-e2e-v2|GitHub|faros-ai"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 3`] = `"mutation { insert_vcs_Branch (objects: [{name: "foo", origin: "mytestsource"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt name repositoryId } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 4`] = `"mutation { insert_vcs_Branch (objects: [{name: "main", origin: "mytestsource", repositoryId: "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt name repositoryId } } }"`;
+
+exports[`graphql-client write batch upsert record with null primary key field 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: "faros-ai", origin: "mytestsource"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 1`] = `"mutation { insert_vcs_User (objects: [{uid: "dbruno21", source: "GitHub"}], on_conflict: {constraint: vcs_User_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 2`] = `"mutation { insert_vcs_Organization (objects: [{uid: "princode-ar", source: "GitHub"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 3`] = `"mutation { insert_vcs_UserTool (objects: [{tool: {category: "GitHubCopilot", detail: ""}, userId: "65ecc2833915a71fb0157d2b0d3d9e2b0c6de441", organizationId: "d48dfb1908821e827f371cf370964d7131b69f4c"}], on_conflict: {constraint: vcs_UserTool_pkey, update_columns: [organizationId, tool, userId]}) { returning { id refreshedAt organizationId tool userId } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 4`] = `"mutation { insert_vcs_UserToolUsage (objects: [{usedAt: "2021-10-14T00:53:33-06:00", origin: "mytestsource", userToolId: "f1e4d99accb71ba8ac1b8a1204f84b8211909212"}], on_conflict: {constraint: vcs_UserToolUsage_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt usedAt userToolId } } }"`;
+
+exports[`graphql-client write batch upsert resetData 1`] = `
+"query paginatedQuery($id: String, $limit: Int) {
+  vcs_Organization(
+    where: {_and: [{_and: {refreshedAt: {_lt: "2200-01-01T00:00:00.000Z"}, origin: {_eq: "foo"}}}, {id: {_gt: $id}}]}
+    order_by: {id: asc}
+    limit: $limit
+  ) {
+    _id: id
+    id
+  }
+}"
+`;
+
+exports[`graphql-client write batch upsert resetData 2`] = `
+{
+  "id": "",
+  "limit": 3,
+}
+`;
+
+exports[`graphql-client write batch upsert resetData 3`] = `
+"mutation {
+
+      del: delete_vcs_Organization(where:{id: {_in:[
+        "00042ddb78c1a5956320e7fbc7ca488517a9caa8","0008d73ec6b79910fcbadb7410c4d191e92ce44d","0011f5f8600d14dae163a37286aa1cd5e6bf6a71"
+      ]}}) {
+        affected_rows
+      }
+    }"
+`;
+
+exports[`graphql-client write batch upsert resetData 4`] = `undefined`;
+
+exports[`graphql-client write batch upsert resetData 5`] = `
+"query paginatedQuery($id: String, $limit: Int) {
+  vcs_Organization(
+    where: {_and: [{_and: {refreshedAt: {_lt: "2200-01-01T00:00:00.000Z"}, origin: {_eq: "foo"}}}, {id: {_gt: $id}}]}
+    order_by: {id: asc}
+    limit: $limit
+  ) {
+    _id: id
+    id
+  }
+}"
+`;
+
+exports[`graphql-client write batch upsert resetData 6`] = `
+{
+  "id": "0011f5f8600d14dae163a37286aa1cd5e6bf6a71",
+  "limit": 3,
+}
+`;
+
+exports[`graphql-client write batch upsert resetData 7`] = `
+"mutation {
+
+      del: delete_vcs_Organization(where:{id: {_in:[
+        "0017bcda1dfcf5b5c2db430849a4bf90f8c51be4","001d319806cb4e608aec2f47f3a2028c41b64321"
+      ]}}) {
+        affected_rows
+      }
+    }"
+`;
+
+exports[`graphql-client write batch upsert resetData 8`] = `undefined`;
+
+exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: "7"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [uid]}) { returning { id refreshedAt uid } } }"`;
+
+exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: "9", origin: "mytestsource"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt uid } } }"`;
+
+exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: "10", origin: "mytestsource", managerId: "t1|gql-e2e-v2|7"}, {uid: "7", origin: "mytestsource", managerId: "t1|gql-e2e-v2|9"}, {uid: "8", origin: "mytestsource", managerId: "t1|gql-e2e-v2|9"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin, refreshedAt]}) { returning { id refreshedAt uid } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: "playg", source: "Bitbucket"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 2`] = `"mutation { insert_vcs_Repository (objects: [{name: "repo1", organizationId: "4d1025a2cfb95b311b9871a49de3a56bf594beee"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 3`] = `"mutation { insert_vcs_Commit (objects: [{sha: "b500332b58c74fc15302c8961e54facf66c16c44", origin: "my-origin", repositoryId: "f9b8248bfcbd563eb23d05a8b1c188a873de787e"}], on_conflict: {constraint: vcs_Commit_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt repositoryId sha } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 4`] = `"mutation { insert_vcs_PullRequest (objects: [{number: 2, origin: "my-origin", repositoryId: "f9b8248bfcbd563eb23d05a8b1c188a873de787e"}], on_conflict: {constraint: vcs_PullRequest_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt number repositoryId } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 5`] = `"mutation { m0: insert_vcs_PullRequest_one (object: {number: 2, repository: {data: {name: "repo1", organization: {data: {uid: "playg", source: "Bitbucket"}, on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}}}, on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}}, mergeCommit: {data: {sha: "b500332b58c74fc15302c8961e54facf66c16c44", repository: {data: {name: "repo1", organization: {data: {uid: "playg", source: "Bitbucket"}, on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}}}, on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}}}, on_conflict: {constraint: vcs_Commit_pkey, update_columns: [repositoryId, sha]}}, mergedAt: "2022-09-21T03:00:27.505Z", origin: "my-transform-origin"}, on_conflict: {constraint: vcs_PullRequest_pkey, update_columns: [mergeCommitId, mergedAt]}) { id } }"`;
+
+exports[`graphql-client write batch upsert upsert same object 1`] = `"mutation { insert_vcs_User (objects: [{uid: "jeniii", name: "some-name", email: "some-email", htmlUrl: "https://github.com/jeniii", origin: "mytestsource"}], on_conflict: {constraint: vcs_User_pkey, update_columns: [email, htmlUrl, name, origin, refreshedAt]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`groupByKeys 1 group of 2 1`] = `
+[
+  [
+    "u0a",
+    "u0b",
+  ],
+]
+`;
+
+exports[`groupByKeys 2 groups of 1 1`] = `
+[
+  [
+    "u0a",
+  ],
+  [
+    "u1a",
+  ],
+]
+`;
+
+exports[`groupByKeys 2 groups of mix 1`] = `
+[
+  [
+    "u0a",
+  ],
+  [
+    "u1a",
+    "u1b",
+  ],
+]
+`;
+
+exports[`groupByKeys 3 groups of 2 1`] = `
+[
+  [
+    "u0a",
+    "u0b",
+  ],
+  [
+    "u1a",
+    "u1b",
+  ],
+  [
+    "u2a",
+    "u2b",
+  ],
+]
+`;
+
+exports[`toLevels ignore other models 1`] = `
+[
+  [
+    "u0",
+  ],
+  [
+    "u2",
+  ],
+]
+`;
+
+exports[`toLevels imbalanced tree 1`] = `
+[
+  [
+    "u0",
+    "u3",
+  ],
+  [
+    "u1",
+  ],
+  [
+    "u2",
+  ],
+]
+`;
+
+exports[`toLevels simple chain 1`] = `
+[
+  [
+    "u0",
+  ],
+  [
+    "u1",
+  ],
+  [
+    "u2",
+  ],
+]
+`;
+
+exports[`toLevels simple chain 2`] = `
+[
+  [
+    "u0",
+  ],
+  [
+    "u1",
+  ],
+]
+`;
+
+exports[`toLevels simple chain 3`] = `
+[
+  [
+    "u0",
+  ],
+]
+`;
+
+exports[`toLevels simple tree 1`] = `
+[
+  [
+    "u0",
+    "u1",
+  ],
+  [
+    "u2",
+  ],
+]
+`;

--- a/test/graphql-client.test.ts
+++ b/test/graphql-client.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
+import pino from 'pino';
 
-import {Schema} from '../src';
+import {Schema, SchemaLoader} from '../src';
 import {
   batchIterator,
   GraphQLBackend,
@@ -15,7 +16,8 @@ import {
   UpsertBuffer,
 } from '../src/graphql/client/graphql-client';
 import {Operation, UpdateRecord} from '../src/graphql/client/types';
-import pino from 'pino';
+
+/*eslint max-len: ["error", { "code": 120 }]*/
 
 describe('graphql-client', () => {
   test('basic batch mutation', () => {
@@ -207,10 +209,12 @@ describe('graphql-client write batch upsert', () => {
       }
     }`);
     const record1 = JSON.parse(
-      '{"name":"foo","uid":"foo","repository":{"name":"metis","uid":"metis","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+      '{"name":"foo","uid":"foo","repository":{"name":"metis","uid":"metis",' +
+      '"organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
     );
     const record2 = JSON.parse(
-      '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+      '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes",' +
+      '"organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
     );
     let queries = 0;
     const backend: GraphQLBackend = {
@@ -226,9 +230,8 @@ describe('graphql-client write batch upsert', () => {
           return Promise.resolve(res2);
         } else if (query.startsWith('mutation { insert_vcs_Branch')) {
           return Promise.resolve(res3);
-        } else {
-          throw new Error('unexpected query ' + query);
         }
+        throw new Error('unexpected query ' + query);
       },
     };
     const client = new GraphQLClient(
@@ -306,7 +309,8 @@ describe('graphql-client write batch upsert', () => {
     const records = [
       JSON.parse('{"name":"foo","uid":"foo"}'),
       JSON.parse(
-        '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+        '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes",' +
+        '"organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
       ),
     ];
     let queries = 0;
@@ -360,9 +364,8 @@ describe('graphql-client write batch upsert', () => {
         queries++;
         if (query.startsWith('mutation { insert_vcs_Organization')) {
           return Promise.resolve(res1);
-        } else {
-          throw new Error('unexpected query ' + query);
         }
+        throw new Error('unexpected query ' + query);
       },
     };
     const client = new GraphQLClient(
@@ -441,7 +444,9 @@ describe('graphql-client write batch upsert', () => {
     }`);
     const responses = [res1, res2, res3, res4];
     const record1 = JSON.parse(
-      '{"userTool":{"user":{"uid":"dbruno21","source":"GitHub"},"organization":{"uid":"princode-ar","source":"GitHub"},"tool":{"category":"GitHubCopilot","detail":""}},"usedAt":"2021-10-14T00:53:33-06:00"}'
+      '{"userTool":{"user":{"uid":"dbruno21","source":"GitHub"},' +
+      '"organization":{"uid":"princode-ar","source":"GitHub"},' +
+      '"tool":{"category":"GitHubCopilot","detail":""}},"usedAt":"2021-10-14T00:53:33-06:00"}'
     );
     let queries = 0;
     const backend: GraphQLBackend = {
@@ -465,7 +470,7 @@ describe('graphql-client write batch upsert', () => {
     await client.flush();
     expect(queries).toEqual(4);
   });
-  test('mergeByPrimaryKey', async () => {
+  test('mergeByPrimaryKey', () => {
     const users = [
       {
         uid: 'tovbinm',
@@ -517,7 +522,7 @@ describe('graphql-client write batch upsert', () => {
     const primaryKeys = ['uid', 'source'];
     expect(mergeByPrimaryKey(users, primaryKeys)).toMatchSnapshot();
   });
-  test('mergeByPrimaryKey - object value', async () => {
+  test('mergeByPrimaryKey - object value', () => {
     const objs = [
       {
         uid: 'tovbinm',
@@ -726,14 +731,16 @@ describe('graphql-client write batch upsert', () => {
         model: 'vcs_PullRequest',
         origin: 'my-origin',
         data: JSON.parse(
-          '{"number":2,"uid":"2","repository":{"name":"repo1","uid":"repo1","organization":{"uid":"playg","source":"Bitbucket"}}}'
+          '{"number":2,"uid":"2","repository":{"name":"repo1","uid":"repo1",' +
+          '"organization":{"uid":"playg","source":"Bitbucket"}}}'
         ),
       },
       {
         model: 'vcs_Commit',
         origin: 'my-origin',
         data: JSON.parse(
-          '{"sha":"b500332b58c74fc15302c8961e54facf66c16c44","uid":"b500332b58c74fc15302c8961e54facf66c16c44","repository":{"name":"repo1","uid":"repo1","organization":{"uid":"playg","source":"Bitbucket"}}}'
+          '{"sha":"b500332b58c74fc15302c8961e54facf66c16c44","uid":"b500332b58c74fc15302c8961e54facf66c16c44",' +
+          '"repository":{"name":"repo1","uid":"repo1","organization":{"uid":"playg","source":"Bitbucket"}}}'
         ),
       },
     ];
@@ -992,7 +999,7 @@ describe('graphql-client write batch upsert', () => {
 });
 
 describe('graphql-client write batch updates', () => {
-  const schemaLoader = {
+  const schemaLoader: SchemaLoader = {
     async loadSchema(): Promise<Schema> {
       return await fs.readJson('test/resources/hasura-ce-schema.json', {
         encoding: 'utf-8',
@@ -1049,7 +1056,7 @@ describe('graphql-client write batch updates', () => {
 });
 
 describe('upsert buffer', () => {
-  test('basic', async () => {
+  test('basic', () => {
     const buf = new UpsertBuffer();
     buf.add({model: 'm1', object: {}, foreignKeys: {}});
     expect(buf.size()).toEqual(1);
@@ -1067,11 +1074,11 @@ describe('upsert buffer', () => {
 });
 
 describe('graphql-client utilities', () => {
-  test('serialize', async () => {
+  test('serialize', () => {
     expect(serialize({z: 1, a: 'bar'})).toEqual('a:bar|z:1');
     expect(serialize({})).toEqual('');
   });
-  test('strictPick', async () => {
+  test('strictPick', () => {
     expect(strictPick({z: 0, a: 'bar'}, ['z', 'b'])).toEqual({z: 0, b: 'null'});
     expect(strictPick({z: 1, a: 'bar'}, ['z', 'b'])).toEqual({z: 1, b: 'null'});
     expect(strictPick({z: 1, a: 'bar'}, ['b'])).toEqual({b: 'null'});
@@ -1251,18 +1258,18 @@ describe('groupByKeys', () => {
 });
 
 describe('toPostgresArrayLiteral', () => {
-  test('strings', async () => {
-    expect(toPostgresArrayLiteral(['a', 'b', 'c'])).toEqual(`{"a","b","c"}`);
-    expect(toPostgresArrayLiteral(['a', '', 'c'])).toEqual(`{"a","","c"}`);
-    expect(toPostgresArrayLiteral(['a', null, 'c'])).toEqual(`{"a",NULL,"c"}`);
+  test('strings', () => {
+    expect(toPostgresArrayLiteral(['a', 'b', 'c'])).toEqual('{"a","b","c"}');
+    expect(toPostgresArrayLiteral(['a', '', 'c'])).toEqual('{"a","","c"}');
+    expect(toPostgresArrayLiteral(['a', null, 'c'])).toEqual('{"a",NULL,"c"}');
     expect(toPostgresArrayLiteral(['a', undefined, 'c'])).toEqual(
-      `{"a",NULL,"c"}`
+      '{"a",NULL,"c"}'
     );
   });
-  test('numbers', async () => {
-    expect(toPostgresArrayLiteral([1, 2, 3])).toEqual(`{1,2,3}`);
-    expect(toPostgresArrayLiteral([1, null, 3])).toEqual(`{1,NULL,3}`);
-    expect(toPostgresArrayLiteral([1, undefined, 3])).toEqual(`{1,NULL,3}`);
-    expect(toPostgresArrayLiteral([1, 0, 3])).toEqual(`{1,0,3}`);
+  test('numbers', () => {
+    expect(toPostgresArrayLiteral([1, 2, 3])).toEqual('{1,2,3}');
+    expect(toPostgresArrayLiteral([1, null, 3])).toEqual('{1,NULL,3}');
+    expect(toPostgresArrayLiteral([1, undefined, 3])).toEqual('{1,NULL,3}');
+    expect(toPostgresArrayLiteral([1, 0, 3])).toEqual('{1,0,3}');
   });
 });

--- a/test/graphql-client.test.ts
+++ b/test/graphql-client.test.ts
@@ -1,0 +1,1268 @@
+import fs from 'fs-extra';
+
+import {Schema} from '../src';
+import {
+  batchIterator,
+  GraphQLBackend,
+  GraphQLClient,
+  groupByKeys,
+  mergeByPrimaryKey,
+  serialize,
+  strictPick,
+  toLevels,
+  toPostgresArrayLiteral,
+  Upsert,
+  UpsertBuffer,
+} from '../src/graphql/client/graphql-client';
+import {Operation, UpdateRecord} from '../src/graphql/client/types';
+import pino from 'pino';
+
+describe('graphql-client', () => {
+  test('basic batch mutation', () => {
+    const json: any = [
+      {
+        mutation: {
+          insert_vcs_Membership_one: {
+            __args: {
+              object: {
+                vcs_User: {
+                  data: {uid: 'ashnet16', source: 'GitHub', origin: 'myghsrc'},
+                  on_conflict: {
+                    constraint: {value: 'vcs_User_pkey'},
+                    update_columns: [{value: 'uid'}, {value: 'source'}],
+                  },
+                },
+                vcs_Organization: {
+                  data: {uid: 'faros-ai', source: 'GitHub', origin: 'myghsrc'},
+                  on_conflict: {
+                    constraint: {value: 'vcs_Organization_pkey'},
+                    update_columns: [{value: 'uid'}, {value: 'source'}],
+                  },
+                },
+                origin: 'myghsrc',
+              },
+              on_conflict: {
+                constraint: {value: 'vcs_Membership_pkey'},
+                update_columns: [{value: 'origin'}, {value: 'refreshedAt'}],
+              },
+            },
+            id: true,
+          },
+        },
+      },
+      {
+        mutation: {
+          insert_vcs_User_one: {
+            __args: {
+              object: {
+                uid: 'betafood',
+                type: {category: 'User', detail: 'user'},
+                source: 'GitHub',
+                origin: 'myghsrc',
+              },
+              on_conflict: {
+                constraint: {value: 'vcs_User_pkey'},
+                update_columns: [
+                  {value: 'email'},
+                  {value: 'name'},
+                  {value: 'origin'},
+                  {value: 'refreshedAt'},
+                  {value: 'type'},
+                  {value: 'url'},
+                ],
+              },
+            },
+            id: true,
+          },
+        },
+      },
+    ];
+    expect(GraphQLClient.batchMutation(json)).toMatchSnapshot();
+  });
+  test('empty batch mutation', () => {
+    expect(GraphQLClient.batchMutation([])).toBeUndefined();
+  });
+  test('no mutations', () => {
+    const json: any = [
+      {
+        query: {
+          insert_vcs_Membership_one: {
+            __args: {
+              object: {
+                vcs_User: {
+                  data: {uid: 'ashnet16', source: 'GitHub', origin: 'myghsrc'},
+                  on_conflict: {
+                    constraint: {value: 'vcs_User_pkey'},
+                    update_columns: [{value: 'uid'}, {value: 'source'}],
+                  },
+                },
+                vcs_Organization: {
+                  data: {uid: 'faros-ai', source: 'GitHub', origin: 'myghsrc'},
+                  on_conflict: {
+                    constraint: {value: 'vcs_Organization_pkey'},
+                    update_columns: [{value: 'uid'}, {value: 'source'}],
+                  },
+                },
+                origin: 'myghsrc',
+              },
+              on_conflict: {
+                constraint: {value: 'vcs_Membership_pkey'},
+                update_columns: [{value: 'origin'}, {value: 'refreshedAt'}],
+              },
+            },
+            id: true,
+          },
+        },
+      },
+      {
+        query: {
+          insert_vcs_User_one: {
+            __args: {
+              object: {
+                uid: 'betafood',
+                type: {category: 'User', detail: 'user'},
+                source: 'GitHub',
+                origin: 'myghsrc',
+              },
+              on_conflict: {
+                constraint: {value: 'vcs_User_pkey'},
+                update_columns: [
+                  {value: 'email'},
+                  {value: 'name'},
+                  {value: 'origin'},
+                  {value: 'refreshedAt'},
+                  {value: 'type'},
+                  {value: 'url'},
+                ],
+              },
+            },
+            id: true,
+          },
+        },
+      },
+    ];
+    expect(GraphQLClient.batchMutation(json)).toBeUndefined();
+  });
+});
+
+describe('graphql-client write batch upsert', () => {
+  const schemaLoader = {
+    async loadSchema(): Promise<Schema> {
+      return await fs.readJson('test/resources/hasura-schema.json', {
+        encoding: 'utf-8',
+      });
+    },
+  };
+  test('basic end-to-end', async () => {
+    const res1 = JSON.parse(`
+    {
+      "data": {
+      "insert_vcs_Organization": {
+        "returning": [
+          {
+            "id": "t1|gql-e2e-v2|GitHub|faros-ai",
+            "uid": "faros-ai",
+            "source": "GitHub"
+            }
+          ]
+        }
+      }
+    }`);
+    const res2 = JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Repository": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "metis",
+              "organizationId": "t1|gql-e2e-v2|GitHub|faros-ai"
+            },
+            {
+              "id": "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "hermes",
+              "organizationId": "t1|gql-e2e-v2|GitHub|faros-ai"
+            }
+          ]
+        }
+      }
+    }`);
+    const res3 = JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Branch": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|foo|t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "foo",
+              "repositoryId": "t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai"
+            },
+            {
+              "id": "t1|gql-e2e-v2|main|t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "main",
+              "repositoryId": "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai"
+            }
+          ]
+        }
+      }
+    }`);
+    const record1 = JSON.parse(
+      '{"name":"foo","uid":"foo","repository":{"name":"metis","uid":"metis","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+    );
+    const record2 = JSON.parse(
+      '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+    );
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        queries++;
+        if (query.startsWith('mutation { insert_vcs_Organization')) {
+          return Promise.resolve(res1);
+        } else if (query.startsWith('mutation { insert_vcs_Repository')) {
+          return Promise.resolve(res2);
+        } else if (query.startsWith('mutation { insert_vcs_Branch')) {
+          return Promise.resolve(res3);
+        } else {
+          throw new Error('unexpected query ' + query);
+        }
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    await client.writeRecord('vcs_Branch', record1, 'mytestsource');
+    await client.writeRecord('vcs_Branch', record2, 'mytestsource');
+    await client.flush();
+    expect(queries).toEqual(3);
+  });
+  test('on_conflict update_columns bug', async () => {
+    const responses = [
+      JSON.parse(`
+    {
+      "data": {
+      "insert_vcs_Organization": {
+        "returning": [
+          {
+            "id": "t1|gql-e2e-v2|GitHub|faros-ai",
+            "uid": "faros-ai",
+            "source": "GitHub"
+            }
+          ]
+        }
+      }
+    }`),
+      JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Repository": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "hermes",
+              "organizationId": "t1|gql-e2e-v2|GitHub|faros-ai"
+            }
+          ]
+        }
+      }
+    }`),
+      JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Branch": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|foo|t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "foo",
+              "repositoryId": null
+            }
+          ]
+        }
+      }
+    }`),
+      JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Branch": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|main|t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "main",
+              "repositoryId": "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai"
+            }
+          ]
+        }
+      }
+    }`),
+    ];
+    const records = [
+      JSON.parse('{"name":"foo","uid":"foo"}'),
+      JSON.parse(
+        '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+      ),
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    for (const record of records) {
+      await client.writeRecord('vcs_Branch', record, 'mytestsource');
+    }
+    await client.flush();
+    expect(queries).toEqual(responses.length);
+  });
+  test('record with null primary key field', async () => {
+    const res1 = JSON.parse(`
+    {
+      "data": {
+      "insert_vcs_Organization": {
+        "returning": [
+          {
+            "id": "t1|gql-e2e-v2|GitHub|faros-ai",
+            "uid": "faros-ai",
+            "source": null
+            }
+          ]
+        }
+      }
+    }`);
+    // org without source (aka null primary key field)
+    const record1 = JSON.parse('{"uid":"faros-ai"}');
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        queries++;
+        if (query.startsWith('mutation { insert_vcs_Organization')) {
+          return Promise.resolve(res1);
+        } else {
+          throw new Error('unexpected query ' + query);
+        }
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    await client.writeRecord('vcs_Organization', record1, 'mytestsource');
+    await client.flush();
+    expect(queries).toEqual(1);
+  });
+  test('record with timestamptz primary key field', async () => {
+    const res1 = JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_User": {
+          "returning": [
+            {
+              "id": "65ecc2833915a71fb0157d2b0d3d9e2b0c6de441",
+              "refreshedAt": "2023-11-27T21:58:24.728607+00:00",
+              "source": "GitHub",
+              "uid": "dbruno21"
+            }
+          ]
+        }
+      }
+    }`);
+    const res2 = JSON.parse(`{
+      "data": {
+        "insert_vcs_Organization": {
+          "returning": [
+            {
+              "id": "d48dfb1908821e827f371cf370964d7131b69f4c",
+              "refreshedAt": "2023-11-27T22:01:28.016928+00:00",
+              "source": "GitHub",
+              "uid": "princode-ar"
+            }
+          ]
+        }
+      }
+    }`);
+    const res3 = JSON.parse(`{
+      "data": {
+        "insert_vcs_UserTool": {
+          "returning": [
+            {
+              "id": "f1e4d99accb71ba8ac1b8a1204f84b8211909212",
+              "refreshedAt": "2023-11-27T22:03:22.424094+00:00",
+              "organizationId": "d48dfb1908821e827f371cf370964d7131b69f4c",
+              "tool": {
+                "detail": "",
+                "category": "GitHubCopilot"
+              },
+              "userId": "65ecc2833915a71fb0157d2b0d3d9e2b0c6de441"
+            }
+          ]
+        }
+      }
+    }`);
+    const res4 = JSON.parse(`{
+      "data": {
+        "insert_vcs_UserToolUsage": {
+          "returning": [
+            {
+              "id": "191d6b4be221e45bfe12b1821796a9cdb0fc0b15",
+              "refreshedAt": "2023-11-27T22:05:13.195912+00:00",
+              "usedAt": "2021-10-14T06:53:33+00:00",
+              "userToolId": "f1e4d99accb71ba8ac1b8a1204f84b8211909212"
+            }
+          ]
+        }
+      }
+    }`);
+    const responses = [res1, res2, res3, res4];
+    const record1 = JSON.parse(
+      '{"userTool":{"user":{"uid":"dbruno21","source":"GitHub"},"organization":{"uid":"princode-ar","source":"GitHub"},"tool":{"category":"GitHubCopilot","detail":""}},"usedAt":"2021-10-14T00:53:33-06:00"}'
+    );
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return Promise.resolve(responses[queries++]);
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    await client.writeRecord('vcs_UserToolUsage', record1, 'mytestsource');
+    await client.flush();
+    expect(queries).toEqual(4);
+  });
+  test('mergeByPrimaryKey', async () => {
+    const users = [
+      {
+        uid: 'tovbinm',
+        name: 'tovbinm',
+        htmlUrl: 'https://github.com/tovbinm',
+        type: {category: 'User', detail: 'user'},
+        source: 'GitHub',
+        origin: 'mytestsource',
+      },
+      {uid: 'tovbinm', source: 'GitHub', origin: 'mytestsource2'},
+      {
+        uid: 'vitalyg',
+        name: 'vitalyg',
+        htmlUrl: 'https://github.com/vitalyg',
+        type: {category: 'User', detail: 'user'},
+        source: 'GitHub',
+        origin: 'mytestsource',
+      },
+      {
+        uid: 'vitalyg',
+        source: 'GitHub',
+        origin: 'mytestsource',
+        type: {foo: 'bar'},
+      },
+      {
+        uid: 'vitalyg',
+        source: null,
+        origin: 'mytestsource',
+        type: {foo: 'bar'},
+      },
+      {
+        uid: 'vitalyg',
+        source: null,
+        name: 'vitality',
+      },
+      {
+        uid: 'jeniii',
+        name: null,
+        email: null,
+        htmlUrl: 'https://github.com/jeniii',
+      },
+      {
+        uid: 'jeniii',
+        name: 'some-name',
+        email: 'some-email',
+        htmlUrl: 'https://github.com/jeniii',
+      },
+    ];
+    const primaryKeys = ['uid', 'source'];
+    expect(mergeByPrimaryKey(users, primaryKeys)).toMatchSnapshot();
+  });
+  test('mergeByPrimaryKey - object value', async () => {
+    const objs = [
+      {
+        uid: 'tovbinm',
+        type: {category: 'c1', detail: 'd1'},
+        origin: 'c1d1',
+      },
+      {
+        uid: 'tovbinm',
+        type: {category: 'c1', detail: 'd1'},
+        origin: 'c1d1-2',
+      },
+      {
+        uid: 'tovbinm',
+        type: {category: 'c1', detail: 'd2'},
+        origin: 'c1d2',
+      },
+    ];
+    const primaryKeys = ['uid', 'type'];
+    expect(mergeByPrimaryKey(objs, primaryKeys)).toMatchSnapshot();
+  });
+  test('self-referent model', async () => {
+    const responses = [
+      // #1
+      JSON.parse(`  
+      {
+        "data": {
+          "insert_org_Employee": {
+            "returning": [
+              {
+                "id": "t1|gql-e2e-v2|7",
+                "uid": "7"
+              },
+              {
+                "id": "t1|gql-e2e-v2|9",
+                "uid": "9"
+              }
+            ]
+          }
+        }
+      }`),
+      // #2
+      JSON.parse(`  
+      {
+        "data": {
+          "insert_org_Employee": {
+            "returning": [
+              {
+                "id": "t1|gql-e2e-v2|9",
+                "uid": "9"
+              }
+            ]
+          }
+        }
+      }`),
+      // #3
+      JSON.parse(`
+      {
+        "data": {
+          "insert_org_Employee": {
+            "returning": [
+              {
+                "id": "t1|gql-e2e-v2|10",
+                "uid": "10"
+              },
+              {
+                "id": "t1|gql-e2e-v2|8",
+                "uid": "8"
+              },
+              {
+                "id": "t1|gql-e2e-v2|7",
+                "uid": "7"
+              }
+            ]
+          }
+        }
+      }`),
+    ];
+    const records = [
+      JSON.parse('{"uid":"10","manager":{"uid":"7"},"source":"BambooHR"}'),
+      JSON.parse('{"uid":"8","manager":{"uid":"9"},"source":"BambooHR"}'),
+      JSON.parse('{"uid":"7","manager":{"uid":"9"},"source":"BambooHR"}'),
+      JSON.parse('{"uid":"9","source":"BambooHR"}'),
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    for (const rec of records) {
+      await client.writeRecord('org_Employee', rec, 'mytestsource');
+    }
+    await client.flush();
+    expect(queries).toEqual(responses.length);
+  });
+  test('update as upsert', async () => {
+    const responses: any[] = [
+      {
+        data: {
+          insert_vcs_Organization: {
+            returning: [
+              {
+                id: '4d1025a2cfb95b311b9871a49de3a56bf594beee',
+                source: 'Bitbucket',
+                uid: 'playg',
+              },
+            ],
+          },
+        },
+      },
+      {
+        data: {
+          insert_vcs_Repository: {
+            returning: [
+              {
+                id: 'f9b8248bfcbd563eb23d05a8b1c188a873de787e',
+                name: 'repo1',
+                organizationId: '4d1025a2cfb95b311b9871a49de3a56bf594beee',
+              },
+            ],
+          },
+        },
+      },
+      {
+        data: {
+          insert_vcs_Commit: {
+            returning: [
+              {
+                id: 'c9edcbbadfd386d367b8a5d6fd33e04937f5ff34',
+                repositoryId: 'f9b8248bfcbd563eb23d05a8b1c188a873de787e',
+                sha: 'b500332b58c74fc15302c8961e54facf66c16c44',
+              },
+            ],
+          },
+        },
+      },
+      {
+        data: {
+          insert_vcs_PullRequest: {
+            returning: [
+              {
+                id: '601bfb71ffa7cac5059940af2508dbce01d023df',
+                number: 2,
+                repositoryId: 'f9b8248bfcbd563eb23d05a8b1c188a873de787e',
+              },
+            ],
+          },
+        },
+      },
+      {
+        data: {
+          m0: {
+            id: '601bfb71ffa7cac5059940af2508dbce01d023df',
+          },
+        },
+      },
+    ];
+    const updateRecord: UpdateRecord = {
+      operation: Operation.UPDATE,
+      model: 'vcs_PullRequest',
+      origin: 'my-transform-origin',
+      at: 1683125806803,
+      where: {
+        number: 2,
+        uid: '2',
+        repository: {
+          uid: 'repo1',
+          name: 'repo1',
+          organization: {
+            uid: 'playg',
+            source: 'Bitbucket',
+          },
+        },
+      },
+      mask: ['mergeCommit', 'mergedAt'],
+      patch: {
+        mergeCommit: {
+          sha: 'b500332b58c74fc15302c8961e54facf66c16c44',
+          uid: 'b500332b58c74fc15302c8961e54facf66c16c44',
+          repository: {
+            uid: 'repo1',
+            name: 'repo1',
+            organization: {
+              uid: 'playg',
+              source: 'Bitbucket',
+            },
+          },
+        },
+        mergedAt: '2022-09-21T03:00:27.505Z',
+      },
+    };
+    const records: {model: string; origin: string; data: any}[] = [
+      {
+        model: 'vcs_PullRequest',
+        origin: 'my-origin',
+        data: JSON.parse(
+          '{"number":2,"uid":"2","repository":{"name":"repo1","uid":"repo1","organization":{"uid":"playg","source":"Bitbucket"}}}'
+        ),
+      },
+      {
+        model: 'vcs_Commit',
+        origin: 'my-origin',
+        data: JSON.parse(
+          '{"sha":"b500332b58c74fc15302c8961e54facf66c16c44","uid":"b500332b58c74fc15302c8961e54facf66c16c44","repository":{"name":"repo1","uid":"repo1","organization":{"uid":"playg","source":"Bitbucket"}}}'
+        ),
+      },
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    for (const rec of records) {
+      await client.writeRecord(rec.model, rec.data, rec.origin);
+    }
+    await client.writeTimestampedRecord(updateRecord);
+    await client.flush();
+    expect(queries).toEqual(responses.length);
+  });
+  test('allow upsert null values', async () => {
+    const responses = [
+      JSON.parse(`
+        {
+          "data": {
+            "insert_vcs_Commit": {
+              "returning": [
+                {
+                  "id": "1603f9d5f6a4d5e5f21c7251a5fc31af20ec0eb3",
+                  "refreshedAt": "2023-06-21T15:20:37.611395+00:00",
+                  "repositoryId": null,
+                  "sha": "c2"
+                }
+              ]
+            }
+          }
+        }
+      `),
+    ];
+    const records = [JSON.parse('{"sha":"c2","author":null, "message":null}')];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    for (const rec of records) {
+      await client.writeRecord('vcs_Commit', rec, 'mytestsource');
+    }
+    await client.flush();
+    expect(queries).toEqual(responses.length);
+  });
+  test('nil uid', async () => {
+    const responses = [
+      JSON.parse(`
+        {
+          "data": {
+            "insert_vcs_Organization": {
+              "returning": [
+                {
+                  "id": "6183747fc59ecd1e8a4d7ebdde6f1e63a8c96468",
+                  "refreshedAt": "2023-06-21T18:48:36.240969+00:00",
+                  "source": null,
+                  "uid": "u1"
+                },
+                {
+                  "id": "87abe37abf99a7946269cc490de66c134d20c68f",
+                  "refreshedAt": "2023-06-21T18:48:36.240969+00:00",
+                  "source": null,
+                  "uid": "u2"
+                }
+              ]
+            }
+          }
+        }
+      `),
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    await client.writeRecord('vcs_Organization', {uid: 'u1'}, 'mytestsource');
+    await expect(
+      client.writeRecord('vcs_Organization', {uid: null}, 'mytestsource')
+    ).rejects.toThrow(
+      'cannot upsert null or undefined uid for model vcs_Organization with keys {"uid":null}'
+    );
+    await client.writeRecord('vcs_Organization', {uid: 'u2'}, 'mytestsource');
+    await client.flush();
+    expect(queries).toEqual(responses.length);
+  });
+  test('upsert same object', async () => {
+    const res1 = JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_User": {
+          "returning": [
+            {
+              "id": "0add74f62dd2509722f89e77805409f364c087df",
+              "refreshedAt": "2024-01-10T00:17:08.106684+00:00",
+              "source": null,
+              "uid": "jeniii"
+            }
+          ]
+        }
+      }
+    }`);
+    const responses = [res1];
+    const record1 = JSON.parse(
+      '{"uid":"jeniii","name":null,"email":null,"htmlUrl":"https://github.com/jeniii"}'
+    );
+    const record2 = JSON.parse(
+      '{"uid":"jeniii","name":"some-name","email":"some-email","htmlUrl":"https://github.com/jeniii"}'
+    );
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return Promise.resolve(responses[queries++]);
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    await client.writeRecord('vcs_User', record1, 'mytestsource');
+    await client.writeRecord('vcs_User', record2, 'mytestsource');
+    await client.flush();
+    expect(queries).toEqual(1);
+  });
+  test('resetData', async () => {
+    const responses = [
+      JSON.parse(`
+        {
+          "data": {
+            "vcs_Organization": [
+              {
+                "_id": "00042ddb78c1a5956320e7fbc7ca488517a9caa8",
+                "id": "00042ddb78c1a5956320e7fbc7ca488517a9caa8"
+              },
+              {
+                "_id": "0008d73ec6b79910fcbadb7410c4d191e92ce44d",
+                "id": "0008d73ec6b79910fcbadb7410c4d191e92ce44d"
+              },
+              {
+                "_id": "0011f5f8600d14dae163a37286aa1cd5e6bf6a71",
+                "id": "0011f5f8600d14dae163a37286aa1cd5e6bf6a71"
+              }
+            ]
+          }
+        }
+      `),
+      JSON.parse(`
+      {
+        "data": {
+          "delete_vcs_Organization": {
+            "affected_rows": 3
+          }
+        }
+      }`),
+      JSON.parse(`
+        {
+          "data": {
+            "vcs_Organization": [
+              {
+                "_id": "0017bcda1dfcf5b5c2db430849a4bf90f8c51be4",
+                "id": "0017bcda1dfcf5b5c2db430849a4bf90f8c51be4"
+              },
+              {
+                "_id": "001d319806cb4e608aec2f47f3a2028c41b64321",
+                "id": "001d319806cb4e608aec2f47f3a2028c41b64321"
+              }
+            ]
+          }
+        }        
+      `),
+      JSON.parse(`
+      {
+        "data": {
+          "delete_vcs_Organization": {
+            "affected_rows": 2
+          }
+        }
+      }`),
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any, variables?: any) {
+        expect(query).toMatchSnapshot();
+        expect(variables).toMatchSnapshot();
+        return Promise.resolve(responses[queries++]);
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      10,
+      1,
+      true,
+      3
+    );
+    await client.loadSchema();
+    await client.resetData(
+      {getOrigin: () => 'foo'},
+      ['vcs_Organization'],
+      false,
+      false
+    );
+    expect(queries).toEqual(responses.length);
+  });
+});
+
+describe('graphql-client write batch updates', () => {
+  const schemaLoader = {
+    async loadSchema(): Promise<Schema> {
+      return await fs.readJson('test/resources/hasura-ce-schema.json', {
+        encoding: 'utf-8',
+      });
+    },
+  };
+
+  test('update_columns bug', async () => {
+    const responses = [
+      JSON.parse(`
+      {
+        "data": {
+          "insert_tms_Task_one": {
+            "returning": [
+              {
+                "id": "t1|gql-e2e-v2|7"
+              }
+            ]
+          }
+        }
+      }`),
+    ];
+    const records = [
+      JSON.parse('{"uid":"9","source":"jira"}'),
+      JSON.parse('{"uid":"7","source":"jira"}'),
+      JSON.parse(
+        '{"uid":"7","parent":{"uid":"9", "source":"jira"},"source":"jira"}'
+      ),
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      pino({name: 'test'}),
+      schemaLoader,
+      backend,
+      0,
+      5
+    );
+    await client.loadSchema();
+    for (const rec of records) {
+      await client.writeRecord('tms_Task', rec, 'mytestsource');
+    }
+    await client.flush();
+    expect(queries).toEqual(responses.length);
+  });
+});
+
+describe('upsert buffer', () => {
+  test('basic', async () => {
+    const buf = new UpsertBuffer();
+    buf.add({model: 'm1', object: {}, foreignKeys: {}});
+    expect(buf.size()).toEqual(1);
+    expect(buf.pop('unknown')).toBeUndefined();
+    buf.add({model: 'm2', object: {}, foreignKeys: {}});
+    buf.add({model: 'm2', object: {}, foreignKeys: {}});
+    expect(buf.size()).toEqual(2);
+    expect(buf.pop('m2')?.length).toEqual(2);
+    expect(buf.size()).toEqual(1);
+    expect(buf.get('m1')?.length).toEqual(1);
+    expect(buf.size()).toEqual(1);
+    expect(buf.pop('m1')?.length).toEqual(1);
+    expect(buf.size()).toEqual(0);
+  });
+});
+
+describe('graphql-client utilities', () => {
+  test('serialize', async () => {
+    expect(serialize({z: 1, a: 'bar'})).toEqual('a:bar|z:1');
+    expect(serialize({})).toEqual('');
+  });
+  test('strictPick', async () => {
+    expect(strictPick({z: 0, a: 'bar'}, ['z', 'b'])).toEqual({z: 0, b: 'null'});
+    expect(strictPick({z: 1, a: 'bar'}, ['z', 'b'])).toEqual({z: 1, b: 'null'});
+    expect(strictPick({z: 1, a: 'bar'}, ['b'])).toEqual({b: 'null'});
+    expect(strictPick({a: 1634194413000}, ['a'], {a: 'timestamptz'})).toEqual({
+      a: 1634194413000,
+    });
+    expect(
+      strictPick({a: '2021-10-14T00:53:33-06:00'}, ['a'], {
+        a: 'timestamptz',
+      })
+    ).toEqual({a: 1634194413000});
+    expect(
+      strictPick({a: '2021-10-14T06:53:33+00:00'}, ['a'], {a: 'timestamptz'})
+    ).toEqual({a: 1634194413000});
+  });
+});
+
+describe('toLevels', () => {
+  async function expectLevels(upserts: Upsert[]): Promise<void> {
+    const iterator = batchIterator(toLevels(upserts), (batch) => {
+      return Promise.resolve(batch.map((u) => u.id).sort());
+    });
+    const res = [];
+    for await (const result of iterator) {
+      res.push(result);
+    }
+    expect(res).toMatchSnapshot();
+  }
+
+  test('simple chain', async () => {
+    const u0: Upsert = {
+      id: 'u0',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u1: Upsert = {
+      id: 'u1',
+      model: 'm',
+      object: {},
+      foreignKeys: {
+        r: u0,
+      },
+    };
+    const u2: Upsert = {
+      id: 'u2',
+      model: 'm',
+      object: {},
+      foreignKeys: {
+        r: u1,
+      },
+    };
+    await expectLevels([u2]);
+    await expectLevels([u1]);
+    await expectLevels([u0]);
+  });
+  test('simple tree', async () => {
+    const u0: Upsert = {
+      id: 'u0',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u1: Upsert = {
+      id: 'u1',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u2: Upsert = {
+      id: 'u2',
+      model: 'm',
+      object: {},
+      foreignKeys: {
+        l: u0,
+        r: u1,
+      },
+    };
+    await expectLevels([u2]);
+  });
+  test('imbalanced tree', async () => {
+    const u0: Upsert = {
+      id: 'u0',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u3: Upsert = {
+      id: 'u3',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u1: Upsert = {
+      id: 'u1',
+      model: 'm',
+      object: {},
+      foreignKeys: {
+        r: u3,
+      },
+    };
+    const u2: Upsert = {
+      id: 'u2',
+      model: 'm',
+      object: {},
+      foreignKeys: {
+        l: u0,
+        r: u1,
+      },
+    };
+    await expectLevels([u2]);
+  });
+  test('ignore other models', async () => {
+    const u0: Upsert = {
+      id: 'u0',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u3: Upsert = {
+      id: 'u3',
+      model: 'm',
+      object: {},
+      foreignKeys: {},
+    };
+    const u1: Upsert = {
+      id: 'u1',
+      model: 'm2', // different model type
+      object: {},
+      foreignKeys: {
+        r: u3,
+      },
+    };
+    const u2: Upsert = {
+      id: 'u2',
+      model: 'm',
+      object: {},
+      foreignKeys: {
+        l: u0,
+        r: u1,
+      },
+    };
+    await expectLevels([u2]);
+  });
+});
+
+describe('groupByKeys', () => {
+  const u0a = {id: 'u0a', f1: 'f1a', f2: 'f2a', f3: 'f3a'};
+  const u0b = {id: 'u0b', f1: 'f1b', f2: 'f2b', f3: 'f3b'};
+  const u1a = {id: 'u1a', f1: 'f1a'};
+  const u1b = {id: 'u1b', f1: 'f1b'};
+  const u2a = {id: 'u2a', f3: 'f3'};
+  const u2b = {id: 'u2b', f3: 'f3'};
+
+  async function expectGroupByKeys(objects: any[]): Promise<void> {
+    const iterator = batchIterator(groupByKeys(objects), (batch) => {
+      return Promise.resolve(batch.map((u) => u.id).sort());
+    });
+    const res = [];
+    for await (const result of iterator) {
+      res.push(result);
+    }
+    expect(res).toMatchSnapshot();
+  }
+  test('3 groups of 2', async () => {
+    await expectGroupByKeys([u0a, u0b, u1a, u1b, u2a, u2b]);
+  });
+  test('1 group of 2', async () => {
+    await expectGroupByKeys([u0a, u0b]);
+  });
+  test('2 groups of 1', async () => {
+    await expectGroupByKeys([u0a, u1a]);
+  });
+  test('2 groups of mix', async () => {
+    await expectGroupByKeys([u0a, u1a, u1b]);
+  });
+});
+
+describe('toPostgresArrayLiteral', () => {
+  test('strings', async () => {
+    expect(toPostgresArrayLiteral(['a', 'b', 'c'])).toEqual(`{"a","b","c"}`);
+    expect(toPostgresArrayLiteral(['a', '', 'c'])).toEqual(`{"a","","c"}`);
+    expect(toPostgresArrayLiteral(['a', null, 'c'])).toEqual(`{"a",NULL,"c"}`);
+    expect(toPostgresArrayLiteral(['a', undefined, 'c'])).toEqual(
+      `{"a",NULL,"c"}`
+    );
+  });
+  test('numbers', async () => {
+    expect(toPostgresArrayLiteral([1, 2, 3])).toEqual(`{1,2,3}`);
+    expect(toPostgresArrayLiteral([1, null, 3])).toEqual(`{1,NULL,3}`);
+    expect(toPostgresArrayLiteral([1, undefined, 3])).toEqual(`{1,NULL,3}`);
+    expect(toPostgresArrayLiteral([1, 0, 3])).toEqual(`{1,0,3}`);
+  });
+});

--- a/test/resources/hasura-ce-schema.json
+++ b/test/resources/hasura-ce-schema.json
@@ -1,0 +1,59 @@
+{
+  "primaryKeys": {
+    "tms_Task": [
+      "source",
+      "uid"
+    ]
+  },
+  "scalars": {
+    "tms_Task": {
+      "additionalFields": "jsonb",
+      "createdAt": "timestamptz",
+      "creator": "String",
+      "description": "String",
+      "epic": "String",
+      "name": "String",
+      "origin": "String",
+      "parent": "String",
+      "points": "Float",
+      "priority": "String",
+      "refreshedAt": "timestamptz",
+      "source": "String",
+      "sprint": "String",
+      "status": "jsonb",
+      "statusChangedAt": "timestamptz",
+      "statusChangelog": "jsonb",
+      "type": "jsonb",
+      "uid": "String",
+      "updatedAt": "timestamptz",
+      "url": "String"
+    }
+  },
+  "references": {
+    "tms_Task": {
+      "parent": {
+        "field": "tms_Task",
+        "model": "tms_Task",
+        "foreignKey": "parent"
+      },
+      "tms_Task": {
+        "field": "tms_Task",
+        "model": "tms_Task",
+        "foreignKey": "parent"
+      }
+    }
+  },
+  "backReferences": {
+    "tms_Task": [
+      {
+        "field": "tms_Tasks",
+        "model": "tms_Task"
+      }
+    ]
+  },
+  "sortedModelDependencies": [
+    "tms_Task"
+  ],
+  "tableNames": [
+    "tms_Task"
+  ]}

--- a/test/resources/hasura-schema.json
+++ b/test/resources/hasura-schema.json
@@ -1,0 +1,331 @@
+{
+  "primaryKeys": {
+    "vcs_Branch": [
+      "name",
+      "repositoryId"
+    ],
+    "vcs_Commit": [
+      "repositoryId",
+      "sha"
+    ],
+    "vcs_Organization": [
+      "source",
+      "uid"
+    ],
+    "vcs_Repository": [
+      "name",
+      "organizationId"
+    ],
+    "org_Employee": [
+      "uid"
+    ],
+    "vcs_PullRequest": [
+      "number",
+      "repositoryId"
+    ],
+    "vcs_User": [
+      "source",
+      "uid"
+    ],
+    "vcs_UserTool": [
+      "organizationId",
+      "tool",
+      "userId"
+    ],
+    "vcs_UserToolUsage": [
+      "usedAt",
+      "userToolId"
+    ]
+  },
+  "scalars": {
+    "vcs_Branch": {
+      "name": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "repositoryId": "String"
+    },
+    "vcs_Commit": {
+      "authorId": "String",
+      "createdAt": "timestamptz",
+      "htmlUrl": "String",
+      "message": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "repositoryId": "String",
+      "sha": "String"
+    },
+    "vcs_Organization": {
+      "createdAt": "timestamptz",
+      "htmlUrl": "String",
+      "name": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "source": "String",
+      "type": "jsonb",
+      "uid": "String"
+    },
+    "vcs_Repository": {
+      "createdAt": "timestamptz",
+      "description": "String",
+      "fullName": "String",
+      "htmlUrl": "String",
+      "included": "Boolean",
+      "language": "String",
+      "mainBranch": "String",
+      "name": "String",
+      "organizationId": "String",
+      "origin": "String",
+      "private": "Boolean",
+      "refreshedAt": "timestamptz",
+      "size": "bigint",
+      "topics": "jsonb",
+      "updatedAt": "timestamptz"
+    },
+    "org_Employee": {
+      "additionalFields": "jsonb",
+      "departmentId": "String",
+      "employmentType": "jsonb",
+      "identityId": "String",
+      "ignored": "Boolean",
+      "inactive": "Boolean",
+      "joinedAt": "timestamptz",
+      "level": "Int",
+      "locationId": "String",
+      "managerId": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "reportingChain": "jsonb",
+      "role": "String",
+      "terminatedAt": "timestamptz",
+      "title": "String",
+      "uid": "String"
+    },
+    "vcs_PullRequest": {
+      "authorId": "String",
+      "commentCount": "Int",
+      "commitCount": "Int",
+      "createdAt": "timestamptz",
+      "description": "String",
+      "diffStats": "jsonb",
+      "htmlUrl": "String",
+      "mergeCommitId": "String",
+      "mergedAt": "timestamptz",
+      "number": "Int",
+      "origin": "String",
+      "readyForReviewAt": "timestamptz",
+      "refreshedAt": "timestamptz",
+      "repositoryId": "String",
+      "state": "jsonb",
+      "title": "String",
+      "updatedAt": "timestamptz"
+    },
+    "vcs_User": {
+      "email": "String",
+      "htmlUrl": "String",
+      "inactive": "Boolean",
+      "name": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "source": "String",
+      "type": "jsonb",
+      "uid": "String"
+    },
+    "vcs_UserTool": {
+      "endedAt": "timestamptz",
+      "inactive": "Boolean",
+      "organizationId": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "startedAt": "timestamptz",
+      "tool": "jsonb",
+      "userId": "String"
+    },
+    "vcs_UserToolUsage": {
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "usedAt": "timestamptz",
+      "userToolId": "String"
+    }
+  },
+  "references": {
+    "vcs_Branch": {
+      "repositoryId": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      },
+      "repository": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      }
+    },
+    "vcs_Commit": {
+      "authorId": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "author": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "repositoryId": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      },
+      "repository": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      }
+    },
+    "vcs_Organization": {},
+    "vcs_Repository": {
+      "organizationId": {
+        "field": "organization",
+        "model": "vcs_Organization",
+        "foreignKey": "organizationId"
+      },
+      "organization": {
+        "field": "organization",
+        "model": "vcs_Organization",
+        "foreignKey": "organizationId"
+      }
+    },
+    "org_Employee": {
+      "departmentId": {
+        "field": "department",
+        "model": "org_Department",
+        "foreignKey": "departmentId"
+      },
+      "department": {
+        "field": "department",
+        "model": "org_Department",
+        "foreignKey": "departmentId"
+      },
+      "identityId": {
+        "field": "identity",
+        "model": "identity_Identity",
+        "foreignKey": "identityId"
+      },
+      "identity": {
+        "field": "identity",
+        "model": "identity_Identity",
+        "foreignKey": "identityId"
+      },
+      "locationId": {
+        "field": "location",
+        "model": "geo_Location",
+        "foreignKey": "locationId"
+      },
+      "location": {
+        "field": "location",
+        "model": "geo_Location",
+        "foreignKey": "locationId"
+      },
+      "managerId": {
+        "field": "manager",
+        "model": "org_Employee",
+        "foreignKey": "managerId"
+      },
+      "manager": {
+        "field": "manager",
+        "model": "org_Employee",
+        "foreignKey": "managerId"
+      }
+    },
+    "vcs_PullRequest": {
+      "authorId": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "author": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "mergeCommitId": {
+        "field": "mergeCommit",
+        "model": "vcs_Commit",
+        "foreignKey": "mergeCommitId"
+      },
+      "mergeCommit": {
+        "field": "mergeCommit",
+        "model": "vcs_Commit",
+        "foreignKey": "mergeCommitId"
+      },
+      "repositoryId": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      },
+      "repository": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      }
+    },
+    "vcs_User": {},
+    "vcs_UserTool": {
+      "organizationId": {
+        "field": "organization",
+        "model": "vcs_Organization",
+        "foreignKey": "organizationId"
+      },
+      "organization": {
+        "field": "organization",
+        "model": "vcs_Organization",
+        "foreignKey": "organizationId"
+      },
+      "userId": {
+        "field": "user",
+        "model": "vcs_User",
+        "foreignKey": "userId"
+      },
+      "user": {
+        "field": "user",
+        "model": "vcs_User",
+        "foreignKey": "userId"
+      }
+    },
+    "vcs_UserToolUsage": {
+      "userToolId": {
+        "field": "userTool",
+        "model": "vcs_UserTool",
+        "foreignKey": "userToolId"
+      },
+      "userTool": {
+        "field": "userTool",
+        "model": "vcs_UserTool",
+        "foreignKey": "userToolId"
+      }
+    }
+  },
+  "backReferences": {},
+  "sortedModelDependencies": [
+    "org_Employee",
+    "vcs_Branch",
+    "vcs_PullRequest",
+    "vcs_Commit",
+    "vcs_Repository",
+    "vcs_UserToolUsage",
+    "vcs_UserTool",
+    "vcs_Organization",
+    "vcs_User"
+  ],
+  "tableNames": [
+    "org_Employee",
+    "vcs_Branch",
+    "vcs_PullRequest",
+    "vcs_Commit",
+    "vcs_Organization",
+    "vcs_Repository",
+    "vcs_User",
+    "vcs_UserTool",
+    "vcs_UserToolUsage"
+  ]
+}


### PR DESCRIPTION
## Description

Move `GraphGLClient` to `faros-js-client` so it can be used in both airbyte-connectors and Hermes.

It is needed in Hermes to improve performance of webhooks and user events.  See [here for details](https://docs.google.com/document/d/11BZVfhCD-R_rGoqmBejliW-94pHnLYHh8xemwTMXERQ/edit?tab=t.0#bookmark=id.4k5vbdyj6ycd) on the changes planned for Hermes. 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
