### PR TITLE
FAI-14965: Fixed hotspots in faros destination

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -132,10 +132,10 @@ function toDateAsISOString(
     return new Date(val).toISOString();
   }
   try {
-    return new Date(toNumber(val)).toISOString();
+    return new Date(val).toISOString();
   } catch {
     try {
-      return new Date(val).toISOString();
+      return new Date(toNumber(val)).toISOString();
     } catch {
       throw new VError('Invalid date: %s', val);
     }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -132,12 +132,12 @@ function toDateAsISOString(
     return new Date(val).toISOString();
   }
   try {
+    // test for integers represented as strings
+    if (/^-?\d+$/.test(val)) {
+      return new Date(toNumber(val)).toISOString();
+    }
     return new Date(val).toISOString();
   } catch {
-    try {
-      return new Date(toNumber(val)).toISOString();
-    } catch {
-      throw new VError('Invalid date: %s', val);
-    }
+    throw new VError('Invalid date: %s', val);
   }
 }


### PR DESCRIPTION
## Description

Two minor fixes that reduce time to run faros destination benchmark by 15%

### benchmark timings

```
 tail -5 ~/baseline.small.log

real	1m3.201s
user	0m19.642s
sys	0m1.071s

$ tail -5 ~/fast.small.log

real	0m51.744s
user	0m16.478s
sys	0m1.171s
```

reduced user time by 15% (i.e. code excluding network calls)

### changes

1. don't use exceptions for flow control in `toDateAsISOString`
2. remove unnecessary copy and avoid `JSON.stringify` in assert in `objectWithForeignKeys`

### baseline toDateAsISOString 7%
<img width="1920" alt="Screenshot 2025-02-05 at 5 15 07 PM" src="https://github.com/user-attachments/assets/8560bb18-b865-4a20-bf28-33b0406cf5e0" />

### after date parsing toDateAsISOString 0.3%
<img width="1920" alt="Screenshot 2025-02-05 at 5 16 00 PM" src="https://github.com/user-attachments/assets/47f0b168-2e45-4c46-a604-d8f5871b4225" />

### baseline for objectWithForeignKeys 10%
<img width="1920" alt="Screenshot 2025-02-05 at 5 19 26 PM" src="https://github.com/user-attachments/assets/ed53bdb5-46b0-4893-9e17-3ebd9c92559f" />

### after changes to objectWithForeignKeys 2.3%
<img width="1920" alt="Screenshot 2025-02-05 at 5 17 17 PM" src="https://github.com/user-attachments/assets/83032802-a717-406b-95cb-16ca031a3a7f" />

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

