### PR TITLE
FAI-22045 - Remove resetData keepReferencedRecords flag

### DIFF
--- a/src/graphql/client/graphql-client.ts
+++ b/src/graphql/client/graphql-client.ts
@@ -376,8 +376,7 @@ export class GraphQLClient {
   async resetData(
     originProvider: OriginProvider,
     models: ReadonlyArray<string>,
-    isResetSync: boolean,
-    keepReferencedRecords: boolean
+    isResetSync: boolean
   ): Promise<void> {
     const schema = this.getSchema();
 
@@ -425,15 +424,6 @@ export class GraphQLClient {
         refreshedAt: {_lt: minRefreshedAt},
         ...originFilter,
       };
-      if (keepReferencedRecords) {
-        deleteConditions._not = {
-          _or: schema.backReferences[model].map((br) => {
-            return {
-              [br.field]: {},
-            };
-          }),
-        };
-      }
       const query = {
         [model]: {
           __args: {

--- a/test/graphql-client.test.ts
+++ b/test/graphql-client.test.ts
@@ -1056,7 +1056,6 @@ describe('graphql-client write batch upsert', () => {
     await client.resetData(
       {getOrigin: () => 'foo'},
       ['vcs_Organization'],
-      false,
       false
     );
     expect(queries).toEqual(responses.length);


### PR DESCRIPTION
## Summary
- remove the legacy `keepReferencedRecords` argument from `GraphQLClient.resetData`
- remove the referenced-record preservation branch that was only needed by Community Edition reset behavior
- update the resetData test call for the new signature

## Historical context
This flag originated in airbyte-connectors, before `GraphQLClient` lived in `faros-js-client`.

Before faros-ai/airbyte-connectors#1023, destination resets always preserved records that were still referenced by other records by adding a `_not` filter built from schema back-references. That behavior existed because the reset logic was originally developed for Faros Community Edition, where Hasura tables had foreign-key relationships that prevented deleting referenced rows.

faros-ai/airbyte-connectors#1023 changed that behavior to be conditional: `keepReferencedRecords` stayed enabled only for `Edition.COMMUNITY`, while SaaS/Cloud reset behavior deleted stale records even if other records referenced them. The PR rationale was that SaaS should match the old V1/phantom behavior: a stale model record should be removed during reset, and existing references can continue pointing at phantoms. The motivating example was a non-incremental Jira `tms_Project`: if a project is renamed, the old project record should be deleted even if other records still reference it.

Later, faros-ai/faros-js-client#353 moved `GraphQLClient` into this repo so it could be shared by airbyte-connectors and Hermes. The `keepReferencedRecords` parameter was carried over as part of that migration.

Since Community Edition is no longer supported, there is no remaining supported caller that should preserve referenced records during reset. Cloud/SaaS behavior is the intended behavior.

Related destination cleanup: faros-ai/airbyte-connectors#2614 leaves a TODO at the remaining packaged-client call site until this cleanup is released and consumed.

## Verification
- `./node_modules/.bin/eslint 'src/**/*.ts' 'test/**/*.ts'`
- `./node_modules/.bin/tsc -p src`
- `./node_modules/.bin/jest test/graphql-client.test.ts --runInBand`